### PR TITLE
fix: args for `execute` command

### DIFF
--- a/src/commands/interaction/execute.ts
+++ b/src/commands/interaction/execute.ts
@@ -1,6 +1,6 @@
 import { Driver } from '../../Driver';
 
-export async function execute(this: Driver, script: string, ...args: any[]): Promise<any> {
+export async function execute(this: Driver, script: string, args: any[]): Promise<any> {
   const [component, method] = script.split(':');
 
   if (!this.roku[component]?.[method]) {


### PR DESCRIPTION
Today during automation was discovered that `args` was not passed correctly to the `node-roku` methods, which was caused by the incorrect assumption that each parameter would be passed as separate argument.