### PR TITLE
fix: application reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
     "mainClass": "Driver"
   },
   "dependencies": {
-    "@dlenroc/roku": "^1.0.0",
+    "@dlenroc/roku": "^1.2.0",
     "appium-base-driver": "^8.0.0-beta.6",
     "appium-support": "^2.51.0",
     "asyncbox": "^2.8.0",
     "base-64": "^1.0.0",
-    "cssesc": "^3.0.0",
-    "jszip": "^3.6.0"
+    "cssesc": "^3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^11.2.0",

--- a/src/commands/app/activateApp.ts
+++ b/src/commands/app/activateApp.ts
@@ -1,8 +1,8 @@
 import { AppId } from '@dlenroc/roku';
 import { Driver } from '../../Driver';
 
-export async function activateApp(this: Driver, id: string): Promise<void> {
-  await this.roku.ecp.launch(id as AppId);
+export async function activateApp(this: Driver, id: string, options?: Record<string, any>): Promise<void> {
+  await this.roku.ecp.launch(id as AppId, options);
   await this.waitForCondition({
     error: 'Channel not started',
     condition: async () => {

--- a/src/commands/app/reset.ts
+++ b/src/commands/app/reset.ts
@@ -1,8 +1,5 @@
 import { Driver } from '../../Driver';
 
 export async function reset(this: Driver): Promise<void> {
-  await this.closeApp();
-  await this.roku.debugServer.clearLaunchCache();
-  await this.roku.debugServer.generateDeveloperKey();
-  await this.launchApp();
+  await this.activateApp('dev', { odc_clear_registry: true });
 }


### PR DESCRIPTION
Previously, resetting the application was done using `genkey` telnet command, which was slow and additionally changed the developer key, so now I switch to the ODC which will quickly clear the registries without touching developer id.