### PR TITLE
fix: key release support

### DIFF
--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -37,6 +37,7 @@ import { submit } from './commands/element/submit';
 import { waitForCondition } from './commands/helpers/waitForCondition';
 import { execute } from './commands/interaction/execute';
 import { performActions } from './commands/interaction/performActions';
+import { releaseActions } from './commands/interaction/releaseActions';
 import { setUrl } from './commands/interaction/setUrl';
 import { hideKeyboard } from './commands/keyboard/hideKeyboard';
 import { isKeyboardShown } from './commands/keyboard/isKeyboardShown';
@@ -52,6 +53,8 @@ import { createSession } from './commands/session/createSession';
 import { deleteSession } from './commands/session/deleteSession';
 
 export class Driver extends BaseDriver {
+  protected pressedKey: string;
+
   public roku: SDK;
   public errors = errors;
   public logger = logger.getLogger('RokuDriver');
@@ -63,6 +66,7 @@ export class Driver extends BaseDriver {
   // Interaction
   public execute = execute;
   public performActions = performActions;
+  public releaseActions = releaseActions;
   public setUrl = setUrl;
 
   // Context
@@ -141,6 +145,13 @@ export class Driver extends BaseDriver {
     username: {
       isString: true,
       presence: false,
+    },
+  };
+
+  static newMethodMap = {
+    '/session/:sessionId/actions': {
+      POST: { command: 'performActions', payloadParams: { required: ['actions'] } },
+      DELETE: { command: 'releaseActions' },
     },
   };
 }

--- a/src/commands/interaction/releaseActions.ts
+++ b/src/commands/interaction/releaseActions.ts
@@ -1,0 +1,7 @@
+import { Driver } from '../../Driver';
+
+export async function releaseActions(this: Driver): Promise<void> {
+  if (this.pressedKey) {
+    await this.performActions({ type: 'keyUp', value: this.pressedKey });
+  }
+}


### PR DESCRIPTION
Few WebDriver clients implementations calls [releaseActions](https://www.w3.org/TR/webdriver/#release-actions) after [performActions](https://www.w3.org/TR/webdriver/#perform-actions) so here I implemented support for that action.
