### PR TITLE
feat: `elementResponseAttributes` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following location strategies are supported: `id`, `tag name`, `css selector
 
 - `ECP` (default) [External Control Protocol](https://github.com/dlenroc/node-roku/blob/main/packages/ecp#readme) is a context which finds elements quickly, but reports incorrect element coordinates and does not see many attributes.
 
-- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context which finds elements more slowly, but sees all attributes and reports coordinates relative to the viewport (may be faster than ECP if `elementResponseAttributes` setting is used).
+- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context that sees all attributes and reports coordinates relative to the viewport (can be tunned using `elementResponseAttributes` setting).
 
 ### Channels
 
@@ -148,6 +148,7 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | `appium:fullReset`                    |    -     | boolean | Stop app, clear app data and uninstall app before session starts and after test                                                 |
 | `appium:printPageSourceOnFindFailure` |    -     | boolean | When a find operation fails, print the current page source. Defaults to `false`                                                 |
 | `appium:newCommandTimeout`            |    -     | number  | How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session |
+| `appium:settings[<key>]`              |    -     |   any   | Update [driver settings](#setting) on session creation                                                                          |
 
 ## Setting
 

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Settings
 
-| Command                                                                                                                                             | Ref                                                                                                                 | Description       |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| [getSettings](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/settings.js#L12)   | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#retrieve-device-settings) | Retrieve settings |
-| [updateSettings](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/settings.js#L5) | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#update-device-settings)   | Update settings   |
+| Command                                                                                                                                           | Ref                                                                                                                 | Description       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| [getSettings](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/settings.js#L12) | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#retrieve-device-settings) | Retrieve settings |
+| [updateSettings](src/commands/settings/updateSettings.ts)                                                                                         | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#update-device-settings)   | Update settings   |
 
 ### Logs
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following location strategies are supported: `id`, `tag name`, `css selector
 
 - `ECP` (default) [External Control Protocol](https://github.com/dlenroc/node-roku/blob/main/packages/ecp#readme) is a context which finds elements quickly, but reports incorrect element coordinates and does not see many attributes.
 
-- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context which finds elements more slowly, but sees all attributes (with primitive types) and reports coordinates relative to the viewport (can be speedup using `elementResponseAttributes` setting).
+- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context which finds elements more slowly, but sees all attributes and reports coordinates relative to the viewport (may be faster than ECP if `elementResponseAttributes` setting is used).
 
 ### Channels
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following location strategies are supported: `id`, `tag name`, `css selector
 
 - `ECP` (default) [External Control Protocol](https://github.com/dlenroc/node-roku/blob/main/packages/ecp#readme) is a context which finds elements quickly, but reports incorrect element coordinates and does not see many attributes.
 
-- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context which finds elements more slowly, but sees all attributes (with primitive types) and reports coordinates relative to the viewport.
+- `ODC` (WIP) [On Device Component](https://github.com/dlenroc/node-roku/blob/main/packages/odc#readme) is a context which finds elements more slowly, but sees all attributes (with primitive types) and reports coordinates relative to the viewport (can be speedup using `elementResponseAttributes` setting).
 
 ### Channels
 
@@ -151,9 +151,9 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ## Setting
 
-| Name                      | Type   | Description                                                                                               |
-| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
-| elementResponseAttributes | string | Comma-separated list of element attribute names that will be available in page source and related actions |
+| Name                        | Type   | Description                                                                                               |
+| --------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
+| `elementResponseAttributes` | string | Comma-separated list of element attribute names that will be available in page source and related actions |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,16 @@ Roku Driver is a WebDriver that allows to test channels using any compatible cli
 
 ## Installation
 
-Install `Appium 2` (if not installed).
-
-```sh
-npm install -g appium@next
-```
-
 Install `roku` driver.
 
 ```sh
-appium driver install --source npm @dlenroc/appium-roku-driver
+npx appium@next driver install --source npm @dlenroc/appium-roku-driver
 ```
 
-Run Appium.
+Run Appium Server.
 
 ```sh
-appium
+npx appium@next server
 
 # Output:
 #   Appium REST http interface listener started on 0.0.0.0:4723
@@ -33,7 +27,7 @@ Thanks to the [Appium](https://github.com/appium/appium) and [WebDriver](https:/
 
 ### Initialization
 
-Like other drivers, roku-driver by default uses the so-called `fast reset` algorithm, in which registries are cleared before each test, and a full reinstallation occurs only if the name or version of the channel is different from the one already installed.
+Like other drivers, roku-driver by default uses the so-called `fast reset` algorithm, in which registries are cleared before each test, and a full reinstallation occurs only if channel differ from the one already installed.
 
 Can be tunned using `noReset`, `fullReset` capabilities.
 
@@ -131,7 +125,7 @@ Below are the key codes and their equivalents in the roku remote.
 
 If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://www.npmjs.com/package/@appium/relaxed-caps-plugin) can be used to get rid of them.
 
-## Roku
+### Roku
 
 | Capability         | Required |  Type  | Description                                                                                                                            |
 | ------------------ | :------: | :----: | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -154,6 +148,12 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | `appium:fullReset`                    |    -     | boolean | Stop app, clear app data and uninstall app before session starts and after test                                                 |
 | `appium:printPageSourceOnFindFailure` |    -     | boolean | When a find operation fails, print the current page source. Defaults to `false`                                                 |
 | `appium:newCommandTimeout`            |    -     | number  | How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session |
+
+## Setting
+
+| Name                      | Type   | Description                                                                                               |
+| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
+| elementResponseAttributes | string | Comma-separated list of element attribute names that will be available in page source and related actions |
 
 ## Commands
 

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -52,8 +52,10 @@ import { isLocked } from './commands/screensaver/isLocked';
 import { unlock } from './commands/screensaver/unlock';
 import { createSession } from './commands/session/createSession';
 import { deleteSession } from './commands/session/deleteSession';
+import { updateSettings } from './commands/settings/updateSettings';
 
 export class Driver extends BaseDriver {
+  protected fields?: Record<string, string[]>;
   protected pressedKey: string;
 
   public roku: SDK;
@@ -63,6 +65,9 @@ export class Driver extends BaseDriver {
   // Session
   public createSession: OmitFirstArg<typeof createSession> = createSession.bind(this, this.createSession.bind(this));
   public deleteSession: OmitFirstArg<typeof deleteSession> = deleteSession.bind(this, this.deleteSession.bind(this));
+
+  // Setting
+  public updateSettings: OmitFirstArg<typeof updateSettings> = updateSettings.bind(this, this.updateSettings.bind(this));
 
   // Interaction
   public execute = execute;

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -55,7 +55,6 @@ import { deleteSession } from './commands/session/deleteSession';
 import { updateSettings } from './commands/settings/updateSettings';
 
 export class Driver extends BaseDriver {
-  protected fields?: Record<string, string[]>;
   protected pressedKey: string;
 
   public roku: SDK;

--- a/src/commands/session/createSession.ts
+++ b/src/commands/session/createSession.ts
@@ -10,6 +10,7 @@ export async function createSession(this: Driver, createSession?: any, jsonwpDes
 
   this.roku = new SDK(ip, username || 'rokudev', password);
   this.roku.document.context = (context as 'ECP' | 'ODC') || this.roku.document.context;
+  await this.updateSettings(await this.getSettings());
 
   const apps = await this.roku.ecp.queryApps();
   let app = apps.find((app) => app.id === 'dev');

--- a/src/commands/settings/updateSettings.ts
+++ b/src/commands/settings/updateSettings.ts
@@ -1,0 +1,32 @@
+import { Driver } from '../../Driver';
+
+export async function updateSettings(this: Driver, updateSettings: any, settings: Record<string, any>): Promise<void> {
+  await updateSettings(settings);
+
+  if (settings.hasOwnProperty('elementResponseAttributes')) {
+    const elementResponseAttributes = settings.elementResponseAttributes;
+
+    if (!elementResponseAttributes) {
+      this.roku.document.fields = null;
+      return;
+    }
+
+    const fields: Record<string, string[]> = {};
+    const attributes = elementResponseAttributes.split(',');
+    for (let attribute of attributes) {
+      let tag = '*';
+
+      if (attribute.includes('/')) {
+        [tag, attribute] = attribute.split('/');
+      }
+
+      if (!fields[tag]) {
+        fields[tag] = [];
+      }
+
+      fields[tag].push(attribute);
+    }
+
+    this.roku.document.fields = fields;
+  }
+}


### PR DESCRIPTION
Added ability to request only needed attributes using `elementResponseAttributes` setting

**Examples:**
- During session creation
```yaml
capabilities:
  ...
  appium:context: ODC
  appium:settings[elementResponseAttributes]: id,visible,focused,text,VKBGrid/currFocusRow,VKBGrid/currFocusColumn
```
- During execution
```typescript
await driver.updateSettings({
  elementResponseAttributes: 'id,visible,focused,text,VKBGrid/currFocusRow,VKBGrid/currFocusColumn'
})
```