### PR TITLE
feat: url in `app` capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | `platformName`                        |    +     | string  | Must be `roku`                                                                                                                  |
 | `appium:automationName`               |    +     | string  | Must be `roku`                                                                                                                  |
 | `appium:deviceName`                   |   +/-    | String  | Helps webdriver clients understand that they are dealing with appium                                                            |
-| `appium:app`                          |    +     | string  | The absolute local path to channel                                                                                              |
+| `appium:app`                          |    +     | string  | The absolute local path or remote http URL to channel                                                                           |
 | `appium:noReset`                      |    -     | boolean | Do not stop app, do not clear app data, and do not uninstall app                                                                |
 | `appium:fullReset`                    |    -     | boolean | Stop app, clear app data and uninstall app before session starts and after test                                                 |
 | `appium:printPageSourceOnFindFailure` |    -     | boolean | When a find operation fails, print the current page source. Defaults to `false`                                                 |

--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
     "appium-support": "^2.53.0",
     "asyncbox": "^2.8.0",
     "base-64": "^1.0.0",
+    "cacache": "^15.2.0",
     "cssesc": "^3.0.0",
-    "jszip": "^3.6.0"
+    "jszip": "^3.6.0",
+    "make-fetch-happen": "^9.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/base-64": "^1.0.0",
+    "@types/cacache": "^15.0.0",
     "rollup": "^2.47.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "typescript": "^4.2.4"

--- a/src/commands/session/createSession.ts
+++ b/src/commands/session/createSession.ts
@@ -32,7 +32,7 @@ export async function createSession(this: Driver, createSession?: any, jsonwpDes
   let source: Buffer;
   if (/^https?:\/\//.test(appPath)) {
     const timestamp = Date.now();
-    const cachePath = resolve(this.opts.tmpDir, 'roku-driver-cache');
+    const cachePath = resolve(this.opts.tmpDir, 'appium-roku-driver');
     const response = await fetch(appPath, { cachePath });
     if (!response.ok) {
       throw new this.errors.SessionNotCreatedError(`Failed to download "${appPath}" -> ${response.status} ${response.statusText}`);


### PR DESCRIPTION
Added ability to use a remote URL as channel source with caching according to [RFC 7234](http://httpwg.org/specs/rfc7234.html) and [RFC 5861](https://tools.ietf.org/html/rfc5861)

**Note:** Channels installed more than 24 hours ago will be automatically deleted during next installation with remote channel