### PR TITLE
feat: `alert` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | [getCurrentContext](src/commands/context/getCurrentContext.ts) | [here](https://appium.io/docs/en/commands/context/get-context/)  | Get current context    |
 | [setContext](src/commands/context/setContext.ts)               | [here](https://appium.io/docs/en/commands/context/set-context/)  | Set context            |
 
+### Dialog
+
+| Command                                                     | Ref                                                         | Description                      |
+| ----------------------------------------------------------- | ----------------------------------------------------------- | -------------------------------- |
+| [getAlertText](src/commands/dialog/getAlertText.ts)         | [here](https://www.w3.org/TR/webdriver/#get-alert-text)     | Get dialog text                  |
+| [isAlertShown](src/commands/dialog/isAlertShown.ts)         | [here](https://webdriver.io/docs/api/chromium/#isalertopen) | Check if dialog is open          |
+| [postAcceptAlert](src/commands/dialog/postAcceptAlert.ts)   | [here](https://www.w3.org/TR/webdriver/#accept-alert)       | Accept dialog using first button |
+| [postDismissAlert](src/commands/dialog/postDismissAlert.ts) | [here](https://www.w3.org/TR/webdriver/#dismiss-alert)      | Dismiss dialog using `Back` key  |
+| [setAlertText](src/commands/dialog/setAlertText.ts)         | [here](https://www.w3.org/TR/webdriver/#send-alert-text)    | Fill dialog with text            |
+
 ### Events
 
 | Command                                                                                                                                           | Ref                                                                  | Description                        |

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -17,6 +17,11 @@ import { terminateApp } from './commands/app/terminateApp';
 import { getContexts } from './commands/context/getContexts';
 import { getCurrentContext } from './commands/context/getCurrentContext';
 import { setContext } from './commands/context/setContext';
+import { getAlertText } from './commands/dialog/getAlertText';
+import { isAlertShown } from './commands/dialog/isAlertShown';
+import { postAcceptAlert } from './commands/dialog/postAcceptAlert';
+import { postDismissAlert } from './commands/dialog/postDismissAlert';
+import { setAlertText } from './commands/dialog/setAlertText';
 import { active } from './commands/element/active';
 import { clear } from './commands/element/clear';
 import { click } from './commands/element/click';
@@ -78,6 +83,13 @@ export class Driver extends BaseDriver {
   public getContexts = getContexts;
   public getCurrentContext = getCurrentContext;
   public setContext = setContext;
+
+  // Dialog
+  public getAlertText = getAlertText;
+  public isAlertShown = isAlertShown;
+  public postAcceptAlert = postAcceptAlert;
+  public postDismissAlert = postDismissAlert;
+  public setAlertText = setAlertText;
 
   // Screensaver
   public isLocked = isLocked;
@@ -168,6 +180,9 @@ export class Driver extends BaseDriver {
   };
 
   static newMethodMap = {
+    '/session/:sessionId/alert': {
+      GET: { command: 'isAlertShown' },
+    },
     '/session/:sessionId/actions': {
       POST: { command: 'performActions', payloadParams: { required: ['actions'] } },
       DELETE: { command: 'releaseActions' },

--- a/src/commands/dialog/getAlertText.ts
+++ b/src/commands/dialog/getAlertText.ts
@@ -1,0 +1,9 @@
+import { Driver } from '../../Driver';
+
+export async function getAlertText(this: Driver): Promise<string> {
+  if (!(await this.isAlertShown())) {
+    throw new this.errors.NoAlertOpenError();
+  }
+
+  return this.roku.document.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"]').text;
+}

--- a/src/commands/dialog/isAlertShown.ts
+++ b/src/commands/dialog/isAlertShown.ts
@@ -1,0 +1,15 @@
+import { Driver } from '../../Driver';
+
+export async function isAlertShown(this: Driver): Promise<boolean> {
+  try {
+    await this.getElOrEls('xpath', '//*[substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"]');
+
+    return true;
+  } catch (e) {
+    if (e instanceof this.errors.NoSuchElementError) {
+      return false;
+    }
+
+    throw e;
+  }
+}

--- a/src/commands/dialog/postAcceptAlert.ts
+++ b/src/commands/dialog/postAcceptAlert.ts
@@ -1,0 +1,23 @@
+import { Driver } from '../../Driver';
+
+export async function postAcceptAlert(this: Driver): Promise<void> {
+  if (!(await this.isAlertShown())) {
+    throw new this.errors.NoAlertOpenError();
+  }
+
+  const button = this.roku.document.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"]//*[substring(name(), string-length(name()) - string-length("Button") + 1) = "Button"]');
+
+  if (!button) {
+    throw new this.errors.InvalidElementStateError('Failed to accept dialog');
+  }
+
+  await button.select();
+
+  await this.waitForCondition({
+    error: 'Dialog is still visible',
+    condition: async () => {
+      const isAlertShown = await this.isAlertShown();
+      return !isAlertShown;
+    },
+  });
+}

--- a/src/commands/dialog/postDismissAlert.ts
+++ b/src/commands/dialog/postDismissAlert.ts
@@ -1,0 +1,17 @@
+import { Driver } from '../../Driver';
+
+export async function postDismissAlert(this: Driver): Promise<void> {
+  if (!(await this.isAlertShown())) {
+    throw new this.errors.NoAlertOpenError();
+  }
+
+  await this.roku.ecp.keypress('Back');
+
+  await this.waitForCondition({
+    error: 'Dialog is still visible',
+    condition: async () => {
+      const isAlertShown = await this.isAlertShown();
+      return !isAlertShown;
+    },
+  });
+}

--- a/src/commands/dialog/setAlertText.ts
+++ b/src/commands/dialog/setAlertText.ts
@@ -1,0 +1,17 @@
+import { Driver } from '../../Driver';
+import { isAlertShown } from './isAlertShown';
+
+export async function setAlertText(this: Driver, text: string): Promise<void> {
+  if (!(await this.isAlertShown())) {
+    throw new this.errors.NoAlertOpenError();
+  }
+
+  const keyboard = this.roku.document.xpathSelect('//*[substring(name(), string-length(name()) - string-length("Dialog") + 1) = "Dialog"]//*[substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard" or substring(name(), string-length(name()) - string-length("PinPad") + 1) = "PinPad"]');
+
+  if (!keyboard) {
+    throw new this.errors.InvalidElementStateError('Keyboard is not present');
+  }
+
+  await keyboard.focus();
+  await keyboard.type(text);
+}

--- a/src/commands/dialog/setAlertText.ts
+++ b/src/commands/dialog/setAlertText.ts
@@ -1,5 +1,4 @@
 import { Driver } from '../../Driver';
-import { isAlertShown } from './isAlertShown';
 
 export async function setAlertText(this: Driver, text: string): Promise<void> {
   if (!(await this.isAlertShown())) {


### PR DESCRIPTION
Alert commands are very convenient for simple interaction with roku dialogs, when there is no need to manually find and perform the necessary actions inside the dialog

Commands:
- `getAlertText`
- `isAlertShown`
- `postAcceptAlert`
- `postDismissAlert`
- `setAlertText`