### PR TITLE
feat: `entryPoint` capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,15 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Roku
 
-| Capability         | Required |  Type  | Description                                                                                                                            |
-| ------------------ | :------: | :----: | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `appium:ip`        |    +     | string | The IP address of the target device                                                                                                    |
-| `appium:password`  |    +     | string | Password for the [development environment](https://developer.roku.com/en-gb/docs/developer-program/getting-started/developer-setup.md) |
-| `appium:username`  |    -     | string | Username for the [development environment](https://developer.roku.com/en-gb/docs/developer-program/getting-started/developer-setup.md) |
-| `appium:context`   |    -     | string | Sets the [context](#contexts) to be used, default `ECP`                                                                                |
-| `appium:registry`  |    -     | object | Pre-fills the registry with the specified sections/keys                                                                                |
-| `appium:arguments` |    -     | object | Parameters to be passed to the main method                                                                                             |
+| Capability          | Required |  Type  | Description                                                                                                                            |
+| ------------------- | :------: | :----: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `appium:ip`         |    +     | string | The IP address of the target device                                                                                                    |
+| `appium:password`   |    +     | string | Password for the [development environment](https://developer.roku.com/en-gb/docs/developer-program/getting-started/developer-setup.md) |
+| `appium:username`   |    -     | string | Username for the [development environment](https://developer.roku.com/en-gb/docs/developer-program/getting-started/developer-setup.md) |
+| `appium:context`    |    -     | string | Sets the [context](#contexts) to be used, default `ECP`                                                                                |
+| `appium:registry`   |    -     | object | Pre-fills the registry with the specified sections/keys                                                                                |
+| `appium:arguments`  |    -     | object | Parameters to be passed to the main method                                                                                             |
+| `appium:entryPoint` |    -     | object | Specifies the channel entry point, possible values are `channel`, `screensaver`, `screensaver-settings`                                |
 
 ### Appium
 

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -177,6 +177,11 @@ export class Driver extends BaseDriver {
       isObject: true,
       presence: false,
     },
+    entryPoint: {
+      isString: true,
+      presence: false,
+      inclusion: ['channel', 'screensaver', 'screensaver-settings'],
+    }
   };
 
   static newMethodMap = {

--- a/src/commands/session/createSession.ts
+++ b/src/commands/session/createSession.ts
@@ -11,7 +11,7 @@ const CACHED_APPS_MAX_AGE = 1000 * 60 * 60 * 24; // ms
 export async function createSession(this: Driver, createSession?: any, jsonwpDesiredCapabilities?: Record<string, any>, jsonwpRequiredCaps?: Record<string, any>, w3cCapabilities?: Record<string, any>): Promise<[string, Record<string, any>]> {
   const session = await createSession(jsonwpDesiredCapabilities, jsonwpRequiredCaps, w3cCapabilities);
 
-  const { ip, username, password, app: appPath, context, registry, arguments: args } = this.caps;
+  const { ip, username, password, app: appPath, context, registry, entryPoint, arguments: args } = this.caps;
 
   this.roku = new SDK(ip, username || 'rokudev', password);
   this.roku.document.context = (context as 'ECP' | 'ODC') || this.roku.document.context;
@@ -23,6 +23,10 @@ export async function createSession(this: Driver, createSession?: any, jsonwpDes
 
   if (registry) {
     options.odc_registry = registry;
+  }
+
+  if (entryPoint) {
+    options.odc_entry_point = entryPoint;
   }
 
   if (this.opts.fastReset || this.opts.fullReset) {


### PR DESCRIPTION
Added the ability to specify the channel entry point using `appium:entryPoint` capability

- `channel` - calls `Main` or `RunUserInterface`
- `screensaver` - calls `RunScreenSaver`
- `screensaver-settings` - calls `RunScreenSaverSettings`
