### PR TITLE
chore: switch to stable `@appium/base-driver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,16 @@
 # Appium Roku Driver · [![NPM Version](https://img.shields.io/npm/v/@dlenroc/appium-roku-driver?cacheSeconds=86400)](https://www.npmjs.com/package/@dlenroc/appium-roku-driver) ![Node.js Version](https://img.shields.io/node/v/@dlenroc/appium-roku-driver) [![Node.js CI](https://github.com/dlenroc/appium-roku-driver/actions/workflows/nodejs.yml/badge.svg?branch=main)](https://github.com/dlenroc/appium-roku-driver/actions/workflows/nodejs.yml)
 
-Roku Driver is a WebDriver that allows testing channels/screensavers using any compatible client.
+Roku Driver is a WebDriver that allows testing channels/screensavers using any webdriver client.
 
 ## Installation
 
-Install `roku` driver.
-
 ```sh
-npx appium@next driver install --source npm @dlenroc/appium-roku-driver
-```
-
-Run Appium Server.
-
-```sh
-npx appium@next server
-
-# Output:
-#   Appium REST http interface listener started on 0.0.0.0:4723
-#   Available drivers:
-#     - roku@<version> (automationName 'Roku')
+appium driver install --source npm @dlenroc/appium-roku-driver
 ```
 
 ## Documentation
 
-Thanks to the [Appium](https://github.com/appium/appium) and [WebDriver](https://www.w3.org/TR/webdriver/) protocol, this driver works just like other similar drivers, but there are still a couple of things that are worth mentioning.
+Thanks to the [Appium](https://github.com/appium/appium) and [WebDriver](https://www.w3.org/TR/webdriver/) protocol, this driver works just like other web drivers, but there are a couple of things worth mentioning.
 
 ### Initialization
 
@@ -37,7 +24,7 @@ The following location strategies are supported: `id`, `tag name`, `css selector
 
 ### Deep linking
 
-- `input` - Sends custom events to the current application.
+- `input` - Sends a custom event to the launched channel.
 
   ```js
   driver.url('roku://input?<key>=<value>');
@@ -194,10 +181,10 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Events
 
-| Command                                                                                                                                           | Ref                                                                  | Description                        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------- |
-| [getLogEvents](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/event.js#L23)   | [here](http://appium.io/docs/en/commands/session/events/get-events/) | Get events stored in appium server |
-| [logCustomEvent](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/event.js#L12) | [here](http://appium.io/docs/en/commands/session/events/log-event/)  | Store a custom event               |
+| Command                                                                                                                                     | Ref                                                                  | Description                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------- |
+| [getLogEvents](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/event.js#L23)   | [here](http://appium.io/docs/en/commands/session/events/get-events/) | Get events stored in appium server |
+| [logCustomEvent](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/event.js#L12) | [here](http://appium.io/docs/en/commands/session/events/log-event/)  | Store a custom event               |
 
 ### Element
 
@@ -234,13 +221,13 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Interaction
 
-| Command                                                                                                                                                  | Ref                                                                 | Description                                          |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------- |
-| [execute](src/commands/interaction/execute.ts)                                                                                                           | [here](http://appium.io/docs/en/commands/mobile-command/)           | Execute a command                                    |
-| [executeDriverScript](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/execute.js#L26) | [here](http://appium.io/docs/en/commands/session/execute-driver/)   | Run a WebdriverIO script against the current session |
-| [performActions](src/commands/interaction/performActions.ts)                                                                                             | [here](http://appium.io/docs/en/commands/interactions/actions/)     | Perform a chain or multiple chains of actions        |
-| [releaseActions](src/commands/interaction/releaseActions.ts)                                                                                             | [here](https://www.w3.org/TR/webdriver/#release-actions)            | Release all the keys that are currently depressed    |
-| [setUrl](src/commands/interaction/setUrl.ts)                                                                                                             | [here](http://appium.io/docs/en/commands/web/navigation/go-to-url/) | Open an deep link                                    |
+| Command                                                                                                                                            | Ref                                                                 | Description                                          |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------- |
+| [execute](src/commands/interaction/execute.ts)                                                                                                     | [here](http://appium.io/docs/en/commands/mobile-command/)           | Execute a command                                    |
+| [executeDriverScript](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/execute.js#L26) | [here](http://appium.io/docs/en/commands/session/execute-driver/)   | Run a WebdriverIO script against the current session |
+| [performActions](src/commands/interaction/performActions.ts)                                                                                       | [here](http://appium.io/docs/en/commands/interactions/actions/)     | Perform a chain or multiple chains of actions        |
+| [releaseActions](src/commands/interaction/releaseActions.ts)                                                                                       | [here](https://www.w3.org/TR/webdriver/#release-actions)            | Release all the keys that are currently depressed    |
+| [setUrl](src/commands/interaction/setUrl.ts)                                                                                                       | [here](http://appium.io/docs/en/commands/web/navigation/go-to-url/) | Open an deep link                                    |
 
 ### Keyboard
 
@@ -251,17 +238,17 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Settings
 
-| Command                                                                                                                                           | Ref                                                                                                                 | Description       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| [getSettings](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/settings.js#L12) | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#retrieve-device-settings) | Retrieve settings |
-| [updateSettings](src/commands/settings/updateSettings.ts)                                                                                         | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#update-device-settings)   | Update settings   |
+| Command                                                                                                                                     | Ref                                                                                                                 | Description       |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| [getSettings](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/settings.js#L12) | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#retrieve-device-settings) | Retrieve settings |
+| [updateSettings](src/commands/settings/updateSettings.ts)                                                                                   | [here](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md#update-device-settings)   | Update settings   |
 
 ### Logs
 
-| Command                                                                                                                                      | Ref                                                                   | Description                      |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------- |
-| [getLog](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/log.js#L23)      | [here](http://appium.io/docs/en/commands/session/logs/get-log/)       | Get the log for a given log type |
-| [getLogTypes](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/lib/basedriver/commands/log.js#L18) | [here](http://appium.io/docs/en/commands/session/logs/get-log-types/) | Get available log types          |
+| Command                                                                                                                                | Ref                                                                   | Description                      |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------- |
+| [getLog](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/log.js#L23)      | [here](http://appium.io/docs/en/commands/session/logs/get-log/)       | Get the log for a given log type |
+| [getLogTypes](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/log.js#L18) | [here](http://appium.io/docs/en/commands/session/logs/get-log-types/) | Get available log types          |
 
 ### Screen
 
@@ -281,17 +268,17 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 
 ### Session
 
-| Command                                                                                                                                          | Ref                                                                                                                                 | Description                                        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| [createSession](src/commands/session/createSession.ts)                                                                                           | [here](http://appium.io/docs/en/commands/session/create/)                                                                           | Create a new session                               |
-| [deleteSession](src/commands/session/deleteSession.ts)                                                                                           | [here](http://appium.io/docs/en/commands/session/delete/)                                                                           | End the running session                            |
-| [getSession](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/session.js#L95)  | [here](http://appium.io/docs/en/commands/session/get/)                                                                              | Retrieve the capabilities of the specified session |
-| [getSessions](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/session.js#L82) | [here](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/docs/mjsonwp/protocol-methods.md) | Retrieve a list of currently active sessions       |
+| Command                                                                                                                                    | Ref                                                                                                                                 | Description                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [createSession](src/commands/session/createSession.ts)                                                                                     | [here](http://appium.io/docs/en/commands/session/create/)                                                                           | Create a new session                               |
+| [deleteSession](src/commands/session/deleteSession.ts)                                                                                     | [here](http://appium.io/docs/en/commands/session/delete/)                                                                           | End the running session                            |
+| [getSession](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/session.js#L100) | [here](http://appium.io/docs/en/commands/session/get/)                                                                              | Retrieve the capabilities of the specified session |
+| [getSessions](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/session.js#L87) | [here](https://github.com/appium/appium-base-driver/blob/5521888b0fe3496ce21238cece05c6bb16244f93/docs/mjsonwp/protocol-methods.md) | Retrieve a list of currently active sessions       |
 
 ### Timeouts
 
-| Command                                                                                                                                           | Ref                                                                       | Description                                                               |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [getTimeouts](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/timeout.js#L47)  | [here](https://www.w3.org/TR/webdriver/#get-timeouts)                     | Get timeouts                                                              |
-| [implicitWait](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/timeout.js#L63) | [here](http://appium.io/docs/en/commands/session/timeouts/implicit-wait/) | Set the amount of time the driver should wait when searching for elements |
-| [timeouts](https://github.com/appium/appium-base-driver/blob/d44b4eb7e1d6e7aeeb045a7885bae790b5f19fba/lib/basedriver/commands/timeout.js#L12)     | [here](http://appium.io/docs/en/commands/session/timeouts/timeouts/)      | Set `command`/`implicit` timeout                                          |
+| Command                                                                                                                                     | Ref                                                                       | Description                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [getTimeouts](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/timeout.js#L47)  | [here](https://www.w3.org/TR/webdriver/#get-timeouts)                     | Get timeouts                                                              |
+| [implicitWait](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/timeout.js#L63) | [here](http://appium.io/docs/en/commands/session/timeouts/implicit-wait/) | Set the amount of time the driver should wait when searching for elements |
+| [timeouts](https://github.com/appium/appium/blob/@appium/base-driver@8.1.1/packages/base-driver/lib/basedriver/commands/timeout.js#L12)     | [here](http://appium.io/docs/en/commands/session/timeouts/timeouts/)      | Set `command`/`implicit` timeout                                          |

--- a/package.json
+++ b/package.json
@@ -29,22 +29,22 @@
     "mainClass": "Driver"
   },
   "dependencies": {
+    "@appium/base-driver": "^8.1.1",
     "@dlenroc/roku": "^1.2.0",
-    "appium-base-driver": "^8.0.0-beta.6",
-    "appium-support": "^2.53.0",
-    "asyncbox": "^2.8.0",
+    "appium-support": "^2.54.1",
+    "asyncbox": "^2.9.1",
     "base-64": "^1.0.0",
-    "cacache": "^15.2.0",
+    "cacache": "^15.3.0",
     "cssesc": "^3.0.0",
-    "jszip": "^3.6.0",
-    "make-fetch-happen": "^9.0.2"
+    "jszip": "^3.7.1",
+    "make-fetch-happen": "^9.1.0"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^13.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.4",
     "@types/base-64": "^1.0.0",
-    "@types/cacache": "^15.0.0",
-    "rollup": "^2.47.0",
+    "@types/cacache": "^15.0.1",
+    "rollup": "^2.56.3",
     "rollup-plugin-typescript2": "^0.30.0",
-    "typescript": "^4.2.4"
+    "typescript": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@appium/base-driver": "^8.1.1",
+    "@appium/support": "^2.54.2",
     "@dlenroc/roku": "^1.2.0",
-    "appium-support": "^2.54.1",
     "asyncbox": "^2.9.1",
     "base-64": "^1.0.0",
     "cacache": "^15.3.0",

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -2,8 +2,8 @@
 /// <reference path='../types/appium-base-driver.d.ts'/>
 
 import { BaseDriver, errors, OmitFirstArg } from '@appium/base-driver';
+import { logger } from '@appium/support';
 import { SDK } from '@dlenroc/roku';
-import { logger } from 'appium-support';
 import { activateApp } from './commands/app/activateApp';
 import { background } from './commands/app/background';
 import { closeApp } from './commands/app/closeApp';

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -1,8 +1,8 @@
 /// <reference path='../types/appium-support.d.ts'/>
 /// <reference path='../types/appium-base-driver.d.ts'/>
 
+import { BaseDriver, errors, OmitFirstArg } from '@appium/base-driver';
 import { SDK } from '@dlenroc/roku';
-import { BaseDriver, errors, OmitFirstArg } from 'appium-base-driver';
 import { logger } from 'appium-support';
 import { activateApp } from './commands/app/activateApp';
 import { background } from './commands/app/background';

--- a/src/commands/element/findElOrEls.ts
+++ b/src/commands/element/findElOrEls.ts
@@ -1,6 +1,6 @@
 import { Element, SelectorStrategy } from '@appium/base-driver';
+import { util } from '@appium/support';
 import { Element as XMLElement } from '@dlenroc/roku';
-import { util } from 'appium-support';
 import base64 from 'base-64';
 import cssEscape from 'cssesc';
 import { Driver } from '../../Driver';
@@ -29,7 +29,6 @@ export async function getElOrEls<T extends boolean = false>(this: Driver, strate
   const self = this;
 
   if (!parent) {
-    this.logger.info(`Render app-ui`);
     await this.roku.document.render();
   }
 
@@ -40,19 +39,16 @@ export async function getElOrEls<T extends boolean = false>(this: Driver, strate
 
   switch (strategy) {
     case 'css selector':
-      this.logger.info(`Search by css: "${selector}"`);
       return await findBy(multiple, {
         find: () => parentElement.cssSelect(selector, this.implicitWaitMs / 1000),
         finds: () => parentElement.cssSelectAll(selector, this.implicitWaitMs / 1000),
       });
     case 'xpath':
-      this.logger.info(`Search by xpath: "${selector}"`);
       return await findBy(multiple, {
         find: () => parentElement.xpathSelect(selector, this.implicitWaitMs / 1000),
         finds: () => parentElement.xpathSelectAll(selector, this.implicitWaitMs / 1000),
       });
     case 'element-id':
-      this.logger.info(`Search by element: "${selector}"`);
       selector = base64.decode(selector)
       return await findBy(multiple, {
         find: () => parentElement.xpathSelect(selector),

--- a/src/commands/element/findElOrEls.ts
+++ b/src/commands/element/findElOrEls.ts
@@ -1,5 +1,5 @@
+import { Element, SelectorStrategy } from '@appium/base-driver';
 import { Element as XMLElement } from '@dlenroc/roku';
-import { Element, SelectorStrategy } from 'appium-base-driver';
 import { util } from 'appium-support';
 import base64 from 'base-64';
 import cssEscape from 'cssesc';

--- a/src/commands/interaction/performActions.ts
+++ b/src/commands/interaction/performActions.ts
@@ -1,6 +1,6 @@
 import { Element } from '@appium/base-driver';
+import { util } from '@appium/support';
 import { Key } from '@dlenroc/roku';
-import { util } from 'appium-support';
 import { longSleep } from 'asyncbox';
 import { Driver } from '../../Driver';
 

--- a/src/commands/interaction/performActions.ts
+++ b/src/commands/interaction/performActions.ts
@@ -1,5 +1,5 @@
+import { Element } from '@appium/base-driver';
 import { Key } from '@dlenroc/roku';
-import { Element } from 'appium-base-driver';
 import { util } from 'appium-support';
 import { longSleep } from 'asyncbox';
 import { Driver } from '../../Driver';

--- a/types/appium-base-driver.d.ts
+++ b/types/appium-base-driver.d.ts
@@ -1,4 +1,4 @@
-declare module 'appium-base-driver' {
+declare module '@appium/base-driver' {
   type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
 
   export function routeConfiguringFunction(driver: BaseDriver): any;
@@ -97,7 +97,7 @@ declare module 'appium-base-driver' {
     | 'UnknownMethodError'
     | 'UnsupportedOperationError'
     | 'ProxyRequestError',
-    { new (...args: any[]): Error }
+    { new(...args: any[]): Error }
   >;
 
   export type SelectorStrategy = 'id' | 'tag name' | 'css selector' | 'xpath' | any;

--- a/types/appium-support.d.ts
+++ b/types/appium-support.d.ts
@@ -1,4 +1,4 @@
-declare module 'appium-support' {
+declare module '@appium/support' {
   import { Element } from '@appium/base-driver';
 
   namespace logger {

--- a/types/appium-support.d.ts
+++ b/types/appium-support.d.ts
@@ -1,5 +1,5 @@
 declare module 'appium-support' {
-  import { Element } from 'appium-base-driver';
+  import { Element } from '@appium/base-driver';
 
   namespace logger {
     function getLogger(


### PR DESCRIPTION
Appium recently released a new stable base driver, so now I can finally get rid of the beta version that I used before