### PR TITLE
fix: `noReset` reset strategy

### DIFF
--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -1,7 +1,7 @@
 /// <reference path='../types/appium-support.d.ts'/>
 /// <reference path='../types/appium-base-driver.d.ts'/>
 
-import { BaseDriver, DriverHelpers, errors, OmitFirstArg } from '@appium/base-driver';
+import { BaseDriver, DriverHelpers, errors } from '@appium/base-driver';
 import { logger } from '@appium/support';
 import { SDK } from '@dlenroc/roku';
 import { activateApp } from './commands/activateApp';
@@ -82,8 +82,8 @@ export class Driver extends BaseDriver {
   );
 
   // WebDriver
-  public createSession: OmitFirstArg<typeof createSession> = createSession.bind(this, super.createSession.bind(this));
-  public deleteSession: OmitFirstArg<typeof deleteSession> = deleteSession.bind(this, super.deleteSession.bind(this));
+  public createSession = createSession.bind(this, super.createSession.bind(this));
+  public deleteSession = deleteSession.bind(this, super.deleteSession.bind(this));
   public setUrl = setUrl;
   public getWindowRect = getWindowRect;
   public active = active;
@@ -130,7 +130,7 @@ export class Driver extends BaseDriver {
   public background = background;
   public setValueImmediate = replaceValue;
   public replaceValue = replaceValue;
-  public updateSettings: OmitFirstArg<typeof updateSettings> = updateSettings.bind(this, super.updateSettings.bind(this));
+  public updateSettings = updateSettings.bind(this, super.updateSettings.bind(this));
   public getCurrentContext = getCurrentContext;
   public setContext = setContext;
   public getContexts = getContexts;

--- a/src/commands/createSession.ts
+++ b/src/commands/createSession.ts
@@ -4,7 +4,8 @@ import { Driver } from '../Driver';
 
 export async function createSession(this: Driver, createSession: BaseDriver['createSession'], jwpCaps: {}, jwpReqCaps: {}, w3cCaps: {}): Promise<[string, {}]> {
   const session = await createSession(jwpCaps, jwpReqCaps, w3cCaps);
-  const { ip, username, password, app, context, registry, entryPoint, arguments: args } = this.caps as any;
+
+  const { app, arguments: args, context, entryPoint, ip, noReset, password, registry, username } = this.opts;
 
   this.roku = new SDK(ip, username || 'rokudev', password);
   this.roku.document.context = context || 'ECP';
@@ -12,8 +13,7 @@ export async function createSession(this: Driver, createSession: BaseDriver['cre
   await this.updateSettings(this.settings.getSettings());
   await this.installApp(app);
   await this.activateApp('dev', {
-    odc_enable: true,
-    ...((this.opts.fastReset || this.opts.fullReset) && { odc_clear_registry: true }),
+    odc_clear_registry: !noReset,
     ...(entryPoint && { odc_entry_point: entryPoint }),
     ...(registry && { odc_registry: registry }),
     ...(args && args),

--- a/src/commands/deleteSession.ts
+++ b/src/commands/deleteSession.ts
@@ -2,13 +2,19 @@ import { BaseDriver } from '@appium/base-driver';
 import { Driver } from '../Driver';
 
 export async function deleteSession(this: Driver, deleteSession: BaseDriver['deleteSession']): Promise<void> {
-  if (!this.opts.skipUninstall) {
+  await deleteSession();
+
+  const { fullReset, noReset } = this.opts;
+
+  if (fullReset) {
     const isInstalled = await this.isAppInstalled('dev');
+
     if (isInstalled) {
       await this.removeApp('dev');
     }
   }
 
-  await this.closeApp();
-  await deleteSession();
+  if (!noReset) {
+    await this.closeApp();
+  }
 }

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,5 +1,13 @@
 import { Driver } from '../Driver';
 
 export async function reset(this: Driver): Promise<void> {
-  await this.activateApp('dev', { odc_clear_registry: true });
+  const { app, arguments: args, entryPoint, registry } = this.opts;
+
+  await this.installApp(app);
+  await this.activateApp('dev', {
+    odc_clear_registry: true,
+    ...(entryPoint && { odc_entry_point: entryPoint }),
+    ...(registry && { odc_registry: registry }),
+    ...(args && args),
+  });
 }

--- a/types/appium-base-driver.d.ts
+++ b/types/appium-base-driver.d.ts
@@ -166,7 +166,7 @@ declare module '@appium/base-driver' {
     toggleEnrollTouchId?(enabled: boolean): Promise<void>;
     launchApp?(): Promise<void>;
     closeApp?(): Promise<void>;
-    reset?(): Promise<void>;
+    reset(): Promise<void>;
     background?(seconds: null | number): Promise<void>;
     endCoverage?(intent: string, path: string): Promise<void>;
     getStrings?(language?: string, stringFile?: string): Promise<Record<string, unknown>>;
@@ -380,8 +380,6 @@ declare module '@appium/base-driver' {
     signCount: number;
     largeBlob?: string;
   };
-
-  export type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
 
   export const errors: Record<'NotYetImplementedError' | 'NotImplementedError' | 'BadParametersError' | 'InvalidArgumentError' | 'NoSuchDriverError' | 'NoSuchElementError' | 'UnknownCommandError' | 'StaleElementReferenceError' | 'ElementNotVisibleError' | 'InvalidElementStateError' | 'UnknownError' | 'ElementIsNotSelectableError' | 'ElementClickInterceptedError' | 'ElementNotInteractableError' | 'InsecureCertificateError' | 'JavaScriptError' | 'XPathLookupError' | 'TimeoutError' | 'NoSuchWindowError' | 'NoSuchCookieError' | 'InvalidCookieDomainError' | 'InvalidCoordinatesError' | 'UnableToSetCookieError' | 'UnexpectedAlertOpenError' | 'NoAlertOpenError' | 'ScriptTimeoutError' | 'InvalidElementCoordinatesError' | 'IMENotAvailableError' | 'IMEEngineActivationFailedError' | 'InvalidSelectorError' | 'SessionNotCreatedError' | 'MoveTargetOutOfBoundsError' | 'NoSuchAlertError' | 'NoSuchContextError' | 'InvalidContextError' | 'NoSuchFrameError' | 'UnableToCaptureScreen' | 'UnknownMethodError' | 'UnsupportedOperationError' | 'ProxyRequestError', { new (...args: any[]): Error }>;
 


### PR DESCRIPTION
Updated `deleteSession` to not close the channel when `noReset = true` capability is set.

Also updated the `reset` command to match the behavior of `createSession` (mostly needed when `noReset` is used).