### PR TITLE
feat: make `app` capability optional

### DIFF
--- a/src/CapabilitiesConstraints.ts
+++ b/src/CapabilitiesConstraints.ts
@@ -3,7 +3,7 @@ import type { Constraints } from "@appium/types";
 export const capabilitiesConstraints = {
   app: {
     isString: true,
-    presence: true,
+    presence: false,
   },
   ip: {
     isString: true,

--- a/src/commands/createSession.ts
+++ b/src/commands/createSession.ts
@@ -17,13 +17,15 @@ export async function createSession(
   this.roku = new SDK(ip, username || 'rokudev', password);
   this.roku.document.context = context || 'ECP';
 
-  await this.installApp(app);
-  await this.activateApp('dev', {
-    odc_clear_registry: !noReset,
-    ...(entryPoint && { odc_entry_point: entryPoint }),
-    ...(registry && { odc_registry: registry }),
-    ...(args && args),
-  });
+  if (app) {
+    await this.installApp(app);
+    await this.activateApp('dev', {
+      odc_clear_registry: !noReset,
+      ...(entryPoint && { odc_entry_point: entryPoint }),
+      ...(registry && { odc_registry: registry }),
+      ...(args && args),
+    });
+  }
 
   return session;
 }


### PR DESCRIPTION
Fixes: GH-63

Made the 'app' capability optional to facilitate the initiation of an app-free session. This modification allows for the installation of the app using Appium commands on demand or direct interaction with the device through Appium/Roku-specific commands.

PS: The feature is still limited, so when no app is specified, the following capabilities will be ignored.
- `appium:arguments`
- `appium:registry`
- `appium:entryPoint`