### PR TITLE
refactor: upgrade `Appium` and `Roku SDK`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | `platformName`                        |    +     | string  | Must be `roku`                                                                                                                  |
 | `appium:automationName`               |    +     | string  | Must be `roku`                                                                                                                  |
 | `appium:deviceName`                   |   +/-    | String  | Helps webdriver clients understand that they are dealing with appium                                                            |
-| `appium:app`                          |    +     | string  | The absolute local path or remote http URL to channel                                                                           |
+| `appium:app`                          |    -     | string  | The absolute local path or remote http URL to channel                                                                           |
 | `appium:noReset`                      |    -     | boolean | Do not stop app, do not clear app data, and do not uninstall app                                                                |
 | `appium:fullReset`                    |    -     | boolean | Stop app, clear app data and uninstall app before session starts and after test                                                 |
 | `appium:printPageSourceOnFindFailure` |    -     | boolean | When a find operation fails, print the current page source. Defaults to `false`                                                 |

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3095,17 +3095,17 @@
       }
     },
     "node_modules/libxmljs2": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
-      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
       "hasInstallScript": true,
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.10",
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "bindings": "~1.5.0",
-        "nan": "~2.17.0"
+        "nan": "~2.18.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/lie": {
@@ -3453,9 +3453,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
@@ -4244,25 +4244,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/roku-dom/node_modules/libxmljs2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
-      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "bindings": "~1.5.0",
-        "nan": "~2.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/roku-dom/node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5723,7 +5704,7 @@
         "@dlenroc/roku": "^1.2.0",
         "css-select": "^4.3.0",
         "css-select-base-adapter": "^0.1.1",
-        "libxmljs2": "^0.32.0"
+        "libxmljs2": "0.33.0"
       }
     },
     "@dlenroc/roku-ecp": {
@@ -7721,13 +7702,13 @@
       }
     },
     "libxmljs2": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
-      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
       "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.10",
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "bindings": "~1.5.0",
-        "nan": "~2.17.0"
+        "nan": "~2.18.0"
       }
     },
     "lie": {
@@ -7985,9 +7966,9 @@
       }
     },
     "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -8512,7 +8493,7 @@
       "requires": {
         "css-select": "^5.1.0",
         "css-select-base-adapter": "^0.1.1",
-        "libxmljs2": "^0.33.0"
+        "libxmljs2": "0.33.0"
       },
       "dependencies": {
         "css-select": {
@@ -8559,21 +8540,6 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
           "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
-        },
-        "libxmljs2": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
-          "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
-          "requires": {
-            "@mapbox/node-pre-gyp": "^1.0.11",
-            "bindings": "~1.5.0",
-            "nan": "~2.18.0"
-          }
-        },
-        "nan": {
-          "version": "2.18.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-          "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,58 +9,62 @@
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@appium/base-driver": "^9.4.1",
-        "@appium/support": "^4.1.8",
+        "@appium/base-driver": "^9.4.4",
+        "@appium/support": "^4.1.11",
         "@dlenroc/roku": "^1.2.0",
+        "@dlenroc/roku-developer-server": "^2.0.0",
+        "@dlenroc/roku-ecp": "^2.0.0",
+        "@dlenroc/roku-odc": "^2.0.0",
         "asyncbox": "^3.0.0",
         "base-64": "^1.0.0",
         "cssesc": "^3.0.0",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "roku-dom": "npm:@dlenroc/roku-dom@^2.0.0"
       },
       "devDependencies": {
-        "@appium/types": "^0.14.1",
+        "@appium/types": "^0.15.0",
         "@tsconfig/node18": "^18.2.2",
-        "@types/base-64": "^1.0.1",
-        "@types/cssesc": "^3.0.1",
-        "typescript": "^5.2.2"
+        "@types/base-64": "^1.0.2",
+        "@types/cssesc": "^3.0.2",
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "appium": "^2.2.1"
+        "appium": "^2.3.0"
       }
     },
     "node_modules/@appium/base-driver": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.4.1.tgz",
-      "integrity": "sha512-h18Rsz96oMaqzNeH9ONN3V58JXaXu2jqS/RA6J8jqnXCafHWPT5Qy0Hhlv50rfZR+NLWq6VKVn/Ee75eEXk4RQ==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.4.4.tgz",
+      "integrity": "sha512-oxtXbFWMQVg8Y+lpdv0oL/G4C5TO3Ns7MDL/di2O//GcOMINCq+LJHvpvO2EX3HpLUX35yOu+3TUKQigPWwbQw==",
       "dependencies": {
-        "@appium/support": "^4.1.8",
-        "@appium/types": "^0.14.1",
+        "@appium/support": "^4.1.11",
+        "@appium/types": "^0.15.0",
         "@colors/colors": "1.6.0",
-        "@types/async-lock": "1.4.1",
-        "@types/bluebird": "3.5.41",
-        "@types/express": "4.17.20",
-        "@types/lodash": "4.14.200",
-        "@types/method-override": "0.0.34",
-        "@types/serve-favicon": "2.5.6",
+        "@types/async-lock": "1.4.2",
+        "@types/bluebird": "3.5.42",
+        "@types/express": "4.17.21",
+        "@types/lodash": "4.14.202",
+        "@types/method-override": "0.0.35",
+        "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.0",
-        "asyncbox": "2.9.4",
-        "axios": "1.5.1",
+        "asyncbox": "3.0.0",
+        "axios": "1.6.2",
         "bluebird": "3.7.2",
         "body-parser": "1.20.2",
         "es6-error": "4.1.1",
         "express": "4.18.2",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
-        "lru-cache": "10.0.1",
+        "lru-cache": "10.1.0",
         "method-override": "3.0.0",
         "morgan": "1.10.0",
         "path-to-regexp": "6.2.1",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "3.13.1",
+        "type-fest": "4.8.3",
         "validate.js": "0.13.1"
       },
       "engines": {
@@ -69,21 +73,6 @@
       },
       "optionalDependencies": {
         "spdy": "4.0.2"
-      }
-    },
-    "node_modules/@appium/base-driver/node_modules/asyncbox": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.9.4.tgz",
-      "integrity": "sha512-TCuA73K6Gvn+5tFGsWf4jc+PsR9RmYXw/AF0mv+CRB3VhHLjqHh/w9gPvYILnV0RcRFfjADHtzZexpxWlsP3Tg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@types/bluebird": "^3.5.37",
-        "bluebird": "^3.5.1",
-        "lodash": "^4.17.4",
-        "source-map-support": "^0.5.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@appium/base-driver/node_modules/basic-auth": {
@@ -176,13 +165,13 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "node_modules/@appium/base-plugin": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.22.tgz",
-      "integrity": "sha512-6iXJpvTeRSSXR10JjUkzZdG8BGsUuyKaoAjEDIKEfifRe91AybJSusfKiZPqNdcfwZsO8INezbxJ08QCs/xVug==",
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.25.tgz",
+      "integrity": "sha512-bi2pM76ChfZ8fOG9OUOFovmPmMbUpUAETZar9/NHCOEHtUKV/5K1am/1hCrRmvkeB62UZah9jWSKv1kk61bLpA==",
       "peer": true,
       "dependencies": {
-        "@appium/base-driver": "^9.4.1",
-        "@appium/support": "^4.1.8"
+        "@appium/base-driver": "^9.4.4",
+        "@appium/support": "^4.1.11"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -190,21 +179,19 @@
       }
     },
     "node_modules/@appium/docutils": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-0.4.11.tgz",
-      "integrity": "sha512-U2X0IOnuaaDvFsFulMlkPTYBbLD/UTMkRKYbiiztWyj9pBpvUSeTx60DM8dYCWVzTCl2ewRbVUPeUWQF04/q2A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.1.tgz",
+      "integrity": "sha512-6G0WlosgQ3+S3WLc66GRVGkxeKpMmdmKIcBZTkPt73yNSV5Klu7FLUhEQAKP/hmVorEYs7GqtD6HH6KP7xkSAw==",
       "peer": true,
       "dependencies": {
-        "@appium/support": "^4.1.8",
+        "@appium/support": "^4.1.11",
         "@appium/tsconfig": "^0.x",
-        "@appium/typedoc-plugin-appium": "^0.x",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
-        "@types/which": "3.0.0",
+        "@types/which": "3.0.3",
         "chalk": "4.1.2",
         "consola": "2.15.3",
         "diff": "5.1.0",
         "figures": "3.2.0",
-        "find-up": "5.0.0",
         "json5": "2.2.3",
         "lilconfig": "2.1.0",
         "lodash": "4.17.21",
@@ -213,13 +200,10 @@
         "read-pkg": "5.2.0",
         "semver": "7.5.4",
         "source-map-support": "0.5.21",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
-        "typedoc": "0.23.28",
-        "typedoc-plugin-markdown": "3.14.0",
-        "typedoc-plugin-resolve-crossmodule-references": "0.3.3",
-        "typescript": "5.0.4",
-        "yaml": "2.3.3",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
+        "typescript": "5.2.2",
+        "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
       },
@@ -231,109 +215,25 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@appium/docutils/node_modules/@appium/typedoc-plugin-appium": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@appium/typedoc-plugin-appium/-/typedoc-plugin-appium-0.6.6.tgz",
-      "integrity": "sha512-sZwhveCtUti2QPAhHWysE8IJVyT9KLUwLxXUBnvDjamEm8cuJmqQDDW9nPgv6iiw1bz9ankv/VLYI8egIpTl6g==",
-      "peer": true,
-      "dependencies": {
-        "handlebars": "4.7.8",
-        "lodash": "4.17.21",
-        "pluralize": "8.0.0",
-        "type-fest": "3.13.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=8"
-      },
-      "peerDependencies": {
-        "appium": "^2.0.0-beta.48",
-        "typedoc": "~0.23.14",
-        "typedoc-plugin-markdown": "3.14.0",
-        "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
-        "typescript": "^4.7.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-      "peer": true,
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
-        "shiki": "^0.14.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 14.14"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/typedoc-plugin-markdown": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
-      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
-      "peer": true,
-      "dependencies": {
-        "handlebars": "^4.7.7"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.23.0"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/typedoc-plugin-resolve-crossmodule-references": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-resolve-crossmodule-references/-/typedoc-plugin-resolve-crossmodule-references-0.3.3.tgz",
-      "integrity": "sha512-ZWWBy2WR8z9a6iXYGlyB3KrpV+JDdZv1mndYU6Eh6mInrfMCrQJi3Y5K9ihMBfuaBGB//le1nEmQLgzU3IO+dw==",
-      "deprecated": "Upgrade to typedoc >= 0.24 and remove typedoc-plugin-resolve-crossmodule-references from your dependencies",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.22 <=0.23"
-      }
-    },
     "node_modules/@appium/docutils/node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/@appium/schema": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.4.1.tgz",
-      "integrity": "sha512-tM2y7GQukExrTdm7fjSe4yA8DA+ZCY5gO5O6YciNmQ0vYZkMFWvjmW0uEzyzJ5kuXMLFzBKFG3Sx/YgoL5gO2A==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.5.0.tgz",
+      "integrity": "sha512-HFed9HtFU6+kLdVyp/xpS/Wfcge8PuMS37LJVShviT6OuzHOYvNFx1/y8+KMa/l0Npvll5eafdfHmUsWlRnUAA==",
       "dependencies": {
-        "@types/json-schema": "7.0.14",
+        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       },
@@ -343,31 +243,31 @@
       }
     },
     "node_modules/@appium/support": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-4.1.8.tgz",
-      "integrity": "sha512-bdVevgZecnLmddNH40X02rtJCimSsONWyU65Eq0vFemzcgpSpUuxl6LX3EXVvHMl1jNkkEVIh3G98SxFd17CTw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-4.1.11.tgz",
+      "integrity": "sha512-d6Ujgn5IDlzmepI2i41Z3FexuhipZ2DE2omadNCJRMBlf0dd5cXW54WQjsS/5GI1S9c++/9Mk0aEHl/6RQcOpw==",
       "dependencies": {
         "@appium/tsconfig": "^0.x",
-        "@appium/types": "^0.14.1",
+        "@appium/types": "^0.15.0",
         "@colors/colors": "1.6.0",
-        "@types/archiver": "5.3.4",
-        "@types/base64-stream": "1.0.4",
-        "@types/find-root": "1.1.3",
-        "@types/jsftp": "2.1.4",
-        "@types/klaw": "3.0.5",
-        "@types/lockfile": "1.0.3",
-        "@types/mv": "2.1.3",
-        "@types/ncp": "2.0.7",
-        "@types/npmlog": "4.1.5",
-        "@types/pluralize": "0.0.32",
-        "@types/semver": "7.5.4",
-        "@types/shell-quote": "1.7.3",
-        "@types/supports-color": "8.1.2",
-        "@types/teen_process": "2.0.1",
-        "@types/uuid": "9.0.6",
-        "@types/which": "3.0.0",
+        "@types/archiver": "6.0.2",
+        "@types/base64-stream": "1.0.5",
+        "@types/find-root": "1.1.4",
+        "@types/jsftp": "2.1.5",
+        "@types/klaw": "3.0.6",
+        "@types/lockfile": "1.0.4",
+        "@types/mv": "2.1.4",
+        "@types/ncp": "2.0.8",
+        "@types/npmlog": "7.0.0",
+        "@types/pluralize": "0.0.33",
+        "@types/semver": "7.5.6",
+        "@types/shell-quote": "1.7.5",
+        "@types/supports-color": "8.1.3",
+        "@types/teen_process": "2.0.4",
+        "@types/uuid": "9.0.7",
+        "@types/which": "3.0.3",
         "archiver": "6.0.1",
-        "axios": "1.5.1",
+        "axios": "1.6.2",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
@@ -395,8 +295,8 @@
         "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
         "uuid": "9.0.1",
         "which": "4.0.0",
         "yauzl": "2.10.0"
@@ -422,16 +322,16 @@
       }
     },
     "node_modules/@appium/types": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.14.1.tgz",
-      "integrity": "sha512-dhZOMQ4Bi26HXr3m7cw+GNK5IUZRieGqpEAH2FvaCgOya0i5pN/5DF4dHtvY+gdr2/vhHW87/Df5ucOj0wSzMA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-7Ht9ZdvcgBHc0ecttIlfFSMbVmKNL5YRX05BVCBakArWghN97xGRJ5VoUwgEeR8VE+iK0m+3R1p0/7HIxyqRJg==",
       "dependencies": {
-        "@appium/schema": "^0.4.1",
+        "@appium/schema": "^0.5.0",
         "@appium/tsconfig": "^0.x",
-        "@types/express": "4.17.20",
-        "@types/npmlog": "4.1.5",
-        "@types/ws": "8.5.8",
-        "type-fest": "3.13.1"
+        "@types/express": "4.17.21",
+        "@types/npmlog": "7.0.0",
+        "@types/ws": "8.5.10",
+        "type-fest": "4.8.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -517,17 +417,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -571,16 +460,11 @@
       }
     },
     "node_modules/@dlenroc/roku-developer-server": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-1.0.2.tgz",
-      "integrity": "sha512-vNUWEi08smVJKvrWeE4FJUSS7oy6vcWPxHPVLx5Uj3H+OzLFd9MlMr6NUaO9cr9JPwKeF1R0U3vnaUWFCZQ7lw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-2.0.0.tgz",
+      "integrity": "sha512-9if2Y4mBjs1yrrbz4o6LZTKkwVcbCppgS0aZiY7KW90zgsYE/8z415Rw8BEwkqGeJ+fQ/F6B8oDuPcAgJ0gntA==",
       "dependencies": {
-        "digest-header": "^1.1.0",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=12"
+        "digest-header": "^1.1.0"
       }
     },
     "node_modules/@dlenroc/roku-dom": {
@@ -598,6 +482,35 @@
       }
     },
     "node_modules/@dlenroc/roku-ecp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-2.0.0.tgz",
+      "integrity": "sha512-i2Zbkyd1eevXgkW9nGfF7GWKwXxDwlj3ADXK5Lg3l1HQCxYB0+bvYoK9Jl26OpaKoY5Xwt73kZj6hDLRB9HIRw==",
+      "dependencies": {
+        "fast-xml-parser": "^4.3.2"
+      }
+    },
+    "node_modules/@dlenroc/roku-odc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.0.tgz",
+      "integrity": "sha512-SDsDhub5R5cyr1cwT5z5P8RO39j1Y3Vgt8gjx2uYkFvV4MieN5XgNWwsNFQ1jc0GUedyDJSe40kItGAgoLdEVw==",
+      "dependencies": {
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/@dlenroc/roku/node_modules/@dlenroc/roku-developer-server": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-1.0.2.tgz",
+      "integrity": "sha512-vNUWEi08smVJKvrWeE4FJUSS7oy6vcWPxHPVLx5Uj3H+OzLFd9MlMr6NUaO9cr9JPwKeF1R0U3vnaUWFCZQ7lw==",
+      "dependencies": {
+        "digest-header": "^1.1.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@dlenroc/roku/node_modules/@dlenroc/roku-ecp": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-1.2.2.tgz",
       "integrity": "sha512-KbyUk3TTE5qEbrBkVZPukfIX5k6/E5msUj5eSm4SSC5AVjHXBHewQYQiXD9kiPh9RykOmnplOhJfFnHT3BlDzw==",
@@ -609,7 +522,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/@dlenroc/roku-odc": {
+    "node_modules/@dlenroc/roku/node_modules/@dlenroc/roku-odc": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-1.4.3.tgz",
       "integrity": "sha512-P8l4hdlzLKbXt0neQA8RQ+tvNHEy+0nBEP76ecWT4wU2tOsuWThS19yEImkTPBAHkXXAjyAtdvxiEKkKGGWcSg==",
@@ -754,16 +667,16 @@
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz",
-      "integrity": "sha512-JuIb009FhHuL9priFBho2kv7QmZOydj0LgYvj+h1t0mMCmhM/YmQNRlJR5wVtBZya6wrVFK5Hi5TIbv5BKEx7w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.3.tgz",
+      "integrity": "sha512-lWuod/rh7Xz5uXiEGSfm2Sd5PG7K/6yJfoAZVqzsEswjPJhUz15R7Gn/o8RczA041QS15hBd/BCSeu9vwPArkA==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "chalk": "^4.1.0"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">= 16.14"
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
@@ -799,70 +712,70 @@
       "dev": true
     },
     "node_modules/@types/archiver": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.4.tgz",
-      "integrity": "sha512-Lj7fLBIMwYFgViVVZHEdExZC3lVYsl+QL0VmdNdIzGZH544jHveYWij6qdnBgJQDnR7pMKliN9z2cPZFEbhyPw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.2.tgz",
+      "integrity": "sha512-KmROQqbQzKGuaAbmK+ZcytkJ51+YqDa7NmbXjmtC5YBLSyQYo21YaUnQ3HbaPFKL1ooo6RQ6OPYPIDyxfpDDXw==",
       "dependencies": {
         "@types/readdir-glob": "*"
       }
     },
     "node_modules/@types/argparse": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.12.tgz",
-      "integrity": "sha512-Qt/6lHaSI+idkJKKTixUTm6q1yjm7EE6ZpsKLkJIHQl7NLAX7lMZRFGAEU8kxaWur3N6L2UE7/U7QR46Isi3vg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.14.tgz",
+      "integrity": "sha512-jJ6NMs9rXQ0rsqNt3TL4Elcwhd6wygo3lJOVoiHzURD34vsCcAlw443uGu4PXTtEmMF7sYKoadTCLXNmuJuQGw==",
       "peer": true
     },
     "node_modules/@types/async-lock": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.1.tgz",
-      "integrity": "sha512-tpYc9kp2I8eI6qcDWtD2023jIlJYz6030qR1S5WhRbTK/JJcYdJ8fb2dRKPRgqioxcPZfTPmzl/PemHIPCrA9g=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw=="
     },
     "node_modules/@types/base-64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.1.tgz",
-      "integrity": "sha512-syGYQWNlO2yyGJjyP9i3eZeHZN+QS3V11EnsVwCiYgOQXMmQNAIgVpFsZ146R+o3l9ltB+KEVKsPW8RCyq2EAw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
+      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
       "dev": true
     },
     "node_modules/@types/base64-stream": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.4.tgz",
-      "integrity": "sha512-uIbi6oqvsS9Rw4qtPh1NFHFNL3KnpyScxU/63GEIP4PonSuejuxkccKPPX4KAAVYl2pwMH6BNQKg1XLfxagfJQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.5.tgz",
+      "integrity": "sha512-gXuo/a7pQ1EXlR5ksM2MccBLl6UUgAgnzR01r/QoHnkaSNinmzSdaGcCq5NAxn72dZ5A1zNYQIl+J9hPsBgBrA==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/bluebird": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.41.tgz",
-      "integrity": "sha512-/OT2UoYPu2fqGNS85UYUx0Ke8Zd/vM0/Au0JqLInTprkRO0NexYe7qAUkDsjhsO3BKHI14wX/UhN5SUaoFVDUQ=="
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
+      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A=="
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
-      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.37",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
-      "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/cssesc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cssesc/-/cssesc-3.0.1.tgz",
-      "integrity": "sha512-YBjVYODTD7T/FN8UexqZmrrt2TPDjwUV+VidICyZda0f4o9O9YFH58KUbpD2br5xGdA5/+hKoZFQW0K6ijrGMg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cssesc/-/cssesc-3.0.2.tgz",
+      "integrity": "sha512-Qii6nTRktvtI380EloxH/V7MwgrYxkPgBI+NklUjQuhzgAd1AqT3QDJd+eD+0doRADgfwvtagLRo7JFa7aMHXg==",
       "dev": true
     },
     "node_modules/@types/express": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
-      "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -871,9 +784,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.39",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
-      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
+      "version": "4.17.41",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -882,81 +795,85 @@
       }
     },
     "node_modules/@types/fancy-log": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-2.0.1.tgz",
-      "integrity": "sha512-XUkwOVjG0StZTzw32vHfTGSXmE02/mMfM1Zqouwq2h8rrV/TwLb5TTvePaXO1YqY5yi7u90GsvoRLMqXInaK9Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-2.0.2.tgz",
+      "integrity": "sha512-SXVJvqWjsl90VwBfp7w4iQ0iO+vxAjQImglcpwbV9GkqNoUD5/p9Wsgetl40F1WL7pzWFN/eZPTF1g5FZXJsIw==",
       "peer": true
     },
     "node_modules/@types/find-root": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.3.tgz",
-      "integrity": "sha512-dRJIphFmChb6NoCntSYgC2eCdXcdIXm9/qqV0Mtp8HcyINWK7YZkaLlJQO9TB2rDTo/y35veiCy68IxNV05VMg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.4.tgz",
+      "integrity": "sha512-2EXK/+gVhVgtt4JqThbEncORvpYJKzi9tQGmI3EkU2jTgMzQsrPm/hbd5xe5uPdeFzIW5gh2PRvvPjaUsI8vpg=="
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
-      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/jsftp": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.4.tgz",
-      "integrity": "sha512-AQ5bGKbC5xZwLuz9xPnzp811tm0c4MqThAdXVUZstkv+sz3qyM5Eg4krlqkzvf6sTU8Il5RwVTSdYqNW4oQCxw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.5.tgz",
+      "integrity": "sha512-g2W6f06wXWVYZw3f/z/N5VHRK69kb1nFaNcRnxs6YxwLph+G7ebd0+Aobd3jWu43oZuyHgycpJZPn+YdIU6qRw==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/klaw": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.5.tgz",
-      "integrity": "sha512-sX8M64GwQbEhPA4GrOUYEl/0Cc9oz5Effoaj43B4o3bsVwskxEipparp8tI1E6lhs2s1R1u/0KeNvf/9OR1cAA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.6.tgz",
+      "integrity": "sha512-BErW5TrTz4nzt/c3VRGf0Bug4JyQJ1o807F4mAfXfvOzFZ8SKgFeHJ0T28Y1KtqlMEB+cUgN7S7CsyQDQ/qxqg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha512-p0ZFzoiL0B9MbNaanUV4u86E9k9PaZdhahiKfsOqj30v/vtNz2NyZFp/VJpVp6E7Iy5a9lXozZmnjm7FbtoKnw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/method-override": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-0.0.34.tgz",
-      "integrity": "sha512-3Ga3AZNaHASSMIWM1MxwJL47x6pB/U5ARYNgMnTNYvLDO9p5ZkgTn+Oe1AKiVxat457QN99OXh/zI+BfnrbNxA==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-0.0.35.tgz",
+      "integrity": "sha512-HdhM5xiIV8fwsZ3B8e9IKWJOqEgmXXBJ/qQzhs5Z8idjsszqEX4j/7/QAcso27ArZ1tSBXg2XMlI1cIHAsCTXA==",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/mv": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.3.tgz",
-      "integrity": "sha512-RQ5XrCe7RWGw3K5bsUpeURtqkhP0/hA/hmUz38Uc2J9nRirkJNmcSumHSK7SNbGw62vuIs3x0sy4hGwoXFdLXQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.4.tgz",
+      "integrity": "sha512-MgEHBpXnQo44Q43j8G0Bvp/Yi8LYbC8hxKrRFMgDEDZMmzDKZLgiyMWtW49B37ko+QupgZ3G5rtPUnOGe5ixLw=="
     },
     "node_modules/@types/ncp": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.7.tgz",
-      "integrity": "sha512-Ns28Jr+Me6DeWolxrh6VtjLKWjUxwpnc9/8RLCzvsFvod28bwsI1DOuXrNYs8YExDW7acc/JnZ/vnGe1FUS5Kw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.8.tgz",
+      "integrity": "sha512-pLNWVLCVWBLVM4F2OPjjK6FWFtByFKD7LhHryF+MbVLws7ENj09mKxRFlhkGPOXfJuaBAG+2iADKJsZwnAbYDw==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.40",
-      "license": "MIT"
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.3",
@@ -964,62 +881,62 @@
       "integrity": "sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg=="
     },
     "node_modules/@types/npmlog": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.5.tgz",
-      "integrity": "sha512-Fl3TEbwPoR7V1z6CMJ18whXOUkOYqF5eCkGKTir2VuevdLYUmcwj9mQdvXzuY0oagZBbsy0J7df41jn+ZcwGRA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
+      "integrity": "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/pluralize": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.32.tgz",
-      "integrity": "sha512-exDkoRIkWJlbRDRmtYDbI3ZUE28HwBwHe5VKn4mvpvMW7qIRDHO6URItErBsBSX7J8/PrDLSOHCcbUMFXwA6CA=="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
+      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg=="
     },
     "node_modules/@types/qs": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
-      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg=="
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
-      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-trCChHpWDGCJCUPJRwD62eapW4KOru6h4S7n9KUIESaxhyBM/2Jh20P3XrFRQQ6Df78E/rq2DbUCVZlI8CXPnA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "node_modules/@types/send": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
-      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-favicon": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.6.tgz",
-      "integrity": "sha512-Qm/Fct+DtjepE85kOAvPtI/OkB8gPZkBuVhKSv3Xpmy3J7zboVdUspGZOZJVVDa/U7ypaCt2cF3Xm5A9gqUvmg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.7.tgz",
+      "integrity": "sha512-z9TNUQXdQ+W/OJMP1e3KOYUZ99qJS4+ZfFOIrPGImcayqKoyifbJSEFkVq1MCKBbqjMZpjPj3B5ilrQAR2+TOw==",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
-      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -1027,19 +944,19 @@
       }
     },
     "node_modules/@types/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-CeYcQaOnluyKPHJTuJmaH9RDJEQSVxGMVf2EZab3chpA8sI65FB19t0x3JlS37NbxL+TUottk9pMypMJQcfhIw=="
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="
     },
     "node_modules/@types/supports-color": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.2.tgz",
-      "integrity": "sha512-nhs1D8NjNueBqRBhBTsc81g90g7VBD4wnMTMy9oP+QIldHuJkE655QTL2D1jkj3LyCd+Q5Y69oOpfxN1l0eCMA=="
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
+      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg=="
     },
     "node_modules/@types/teen_process": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.1.tgz",
-      "integrity": "sha512-hSLCkcQa9Ok1Mg0c1NbCJh9km6Gynj/7mHF2wQQNiiugMGkbhGfToZwEW78XRBnlw3784B6C8nsYnVeiU9bEwg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.4.tgz",
+      "integrity": "sha512-AJT0syZovEDa4j17szoRJX5BE2RxD3FVp6SownH43mF16TPnsV0zhtsvFGlgs5QkgsNpoooNnF+HjMow7Jd3jA==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1051,14 +968,14 @@
       "peer": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
-      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
     },
     "node_modules/@types/which": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g=="
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -1067,9 +984,9 @@
       "peer": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1182,12 +1099,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "peer": true
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1203,31 +1114,31 @@
       }
     },
     "node_modules/appium": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-2.2.1.tgz",
-      "integrity": "sha512-9W7QEJEUtRw9czYFaZZT6dBosOIDHbfK4MdCnCLOsvul7nlllrHr3k9TpLbz8SNuFZMDKNaqGE6KDUTez2DN8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/appium/-/appium-2.3.0.tgz",
+      "integrity": "sha512-uhLh+Glfr31vt3R6lnE6+LcBdxDArGKV1FRf072K6DZlEhz94aniRpMwKuMaQ76jfoF3BqWFmEJRIQL+2eRUKQ==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "@appium/base-driver": "^9.4.1",
-        "@appium/base-plugin": "^2.2.22",
-        "@appium/docutils": "^0.4.11",
-        "@appium/schema": "^0.4.1",
-        "@appium/support": "^4.1.8",
-        "@appium/types": "^0.14.1",
-        "@sidvind/better-ajv-errors": "2.1.0",
-        "@types/argparse": "2.0.12",
-        "@types/bluebird": "3.5.41",
-        "@types/fancy-log": "2.0.1",
-        "@types/semver": "7.5.4",
-        "@types/teen_process": "2.0.1",
+        "@appium/base-driver": "^9.4.4",
+        "@appium/base-plugin": "^2.2.25",
+        "@appium/docutils": "^1.0.1",
+        "@appium/schema": "^0.5.0",
+        "@appium/support": "^4.1.11",
+        "@appium/types": "^0.15.0",
+        "@sidvind/better-ajv-errors": "2.1.3",
+        "@types/argparse": "2.0.14",
+        "@types/bluebird": "3.5.42",
+        "@types/fancy-log": "2.0.2",
+        "@types/semver": "7.5.6",
+        "@types/teen_process": "2.0.4",
         "@types/wrap-ansi": "3.0.0",
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
         "argparse": "2.0.1",
         "async-lock": "1.4.0",
-        "asyncbox": "2.9.4",
-        "axios": "1.5.1",
+        "asyncbox": "3.0.0",
+        "axios": "1.6.2",
         "bluebird": "3.7.2",
         "cross-env": "7.0.3",
         "find-up": "5.0.0",
@@ -1239,11 +1150,11 @@
         "resolve-from": "5.0.0",
         "semver": "7.5.4",
         "source-map-support": "0.5.21",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
         "winston": "3.11.0",
         "wrap-ansi": "7.0.0",
-        "yaml": "2.3.3"
+        "yaml": "2.3.4"
       },
       "bin": {
         "appium": "index.js"
@@ -1251,22 +1162,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
-      }
-    },
-    "node_modules/appium/node_modules/asyncbox": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.9.4.tgz",
-      "integrity": "sha512-TCuA73K6Gvn+5tFGsWf4jc+PsR9RmYXw/AF0mv+CRB3VhHLjqHh/w9gPvYILnV0RcRFfjADHtzZexpxWlsP3Tg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@types/bluebird": "^3.5.37",
-        "bluebird": "^3.5.1",
-        "lodash": "^4.17.4",
-        "source-map-support": "^0.5.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/appium/node_modules/wrap-ansi": {
@@ -1424,9 +1319,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2390,17 +2285,17 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
-      "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {
@@ -2736,27 +2631,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "optional": true
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3133,12 +3007,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "peer": true
-    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3333,18 +3201,12 @@
       "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "engines": {
         "node": "14 || >=16.14"
       }
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "peer": true
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -3373,18 +3235,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "peer": true
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3628,12 +3478,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
     },
     "node_modules/node-abi": {
       "version": "3.51.0",
@@ -4213,11 +4057,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4324,6 +4163,106 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/roku-dom": {
+      "name": "@dlenroc/roku-dom",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-dom/-/roku-dom-2.0.0.tgz",
+      "integrity": "sha512-HG9zRDMqBQF9rMku7WW4LpBYVPsRRcERRi2rPX94luTy5iC3yK/vBSyWMdcNwkdsI4llmVWDMIqDaA529ggrDg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-select-base-adapter": "^0.1.1",
+        "libxmljs2": "^0.33.0"
+      },
+      "peerDependencies": {
+        "@dlenroc/roku-ecp": "^2.0.0",
+        "@dlenroc/roku-odc": "^2.0.0"
+      }
+    },
+    "node_modules/roku-dom/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/roku-dom/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/roku-dom/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/roku-dom/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/roku-dom/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/roku-dom/node_modules/libxmljs2": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "bindings": "~1.5.0",
+        "nan": "~2.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/roku-dom/node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -4513,18 +4452,6 @@
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.5.tgz",
-      "integrity": "sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==",
-      "peer": true,
-      "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/side-channel": {
@@ -4906,17 +4833,17 @@
       }
     },
     "node_modules/teen_process": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.0.50.tgz",
-      "integrity": "sha512-DDppkV654MHUqIrZe2M4FK4NmTKxHHHlr/2M9yE0VrsY3iDUsZFbCIBzVEZ9fQ47Cem4JLtUp9ml4FGp3vR+Uw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.1.tgz",
+      "integrity": "sha512-PIX+PyH6h52uJeGpXfjLdIBRim5pPkJTkO/PPeLCa5NlofqlasTjcvNUUYo6XurnxSTl0o17sBzIrVoXNuqwGg==",
       "dependencies": {
-        "bluebird": "3.7.2",
-        "lodash": "4.17.21",
-        "shell-quote": "1.8.1",
-        "source-map-support": "0.5.21"
+        "bluebird": "^3.7.2",
+        "lodash": "^4.17.21",
+        "shell-quote": "^1.8.1",
+        "source-map-support": "^0.x"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "node": "^16.13.0 || >=18.0.0",
         "npm": ">=8"
       }
     },
@@ -5015,11 +4942,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
+      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5038,9 +4965,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5049,18 +4976,10 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unorm": {
       "version": "1.6.0",
@@ -5135,18 +5054,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "peer": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "peer": true
     },
     "node_modules/wbuf": {
       "version": "1.7.3",
@@ -5236,12 +5143,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -5359,9 +5260,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "peer": true,
       "engines": {
         "node": ">= 14"
@@ -5439,51 +5340,39 @@
   },
   "dependencies": {
     "@appium/base-driver": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.4.1.tgz",
-      "integrity": "sha512-h18Rsz96oMaqzNeH9ONN3V58JXaXu2jqS/RA6J8jqnXCafHWPT5Qy0Hhlv50rfZR+NLWq6VKVn/Ee75eEXk4RQ==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.4.4.tgz",
+      "integrity": "sha512-oxtXbFWMQVg8Y+lpdv0oL/G4C5TO3Ns7MDL/di2O//GcOMINCq+LJHvpvO2EX3HpLUX35yOu+3TUKQigPWwbQw==",
       "requires": {
-        "@appium/support": "^4.1.8",
-        "@appium/types": "^0.14.1",
+        "@appium/support": "^4.1.11",
+        "@appium/types": "^0.15.0",
         "@colors/colors": "1.6.0",
-        "@types/async-lock": "1.4.1",
-        "@types/bluebird": "3.5.41",
-        "@types/express": "4.17.20",
-        "@types/lodash": "4.14.200",
-        "@types/method-override": "0.0.34",
-        "@types/serve-favicon": "2.5.6",
+        "@types/async-lock": "1.4.2",
+        "@types/bluebird": "3.5.42",
+        "@types/express": "4.17.21",
+        "@types/lodash": "4.14.202",
+        "@types/method-override": "0.0.35",
+        "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.0",
-        "asyncbox": "2.9.4",
-        "axios": "1.5.1",
+        "asyncbox": "3.0.0",
+        "axios": "1.6.2",
         "bluebird": "3.7.2",
         "body-parser": "1.20.2",
         "es6-error": "4.1.1",
         "express": "4.18.2",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
-        "lru-cache": "10.0.1",
+        "lru-cache": "10.1.0",
         "method-override": "3.0.0",
         "morgan": "1.10.0",
         "path-to-regexp": "6.2.1",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
         "spdy": "4.0.2",
-        "type-fest": "3.13.1",
+        "type-fest": "4.8.3",
         "validate.js": "0.13.1"
       },
       "dependencies": {
-        "asyncbox": {
-          "version": "2.9.4",
-          "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.9.4.tgz",
-          "integrity": "sha512-TCuA73K6Gvn+5tFGsWf4jc+PsR9RmYXw/AF0mv+CRB3VhHLjqHh/w9gPvYILnV0RcRFfjADHtzZexpxWlsP3Tg==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "@types/bluebird": "^3.5.37",
-            "bluebird": "^3.5.1",
-            "lodash": "^4.17.4",
-            "source-map-support": "^0.5.5"
-          }
-        },
         "basic-auth": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -5565,31 +5454,29 @@
       }
     },
     "@appium/base-plugin": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.22.tgz",
-      "integrity": "sha512-6iXJpvTeRSSXR10JjUkzZdG8BGsUuyKaoAjEDIKEfifRe91AybJSusfKiZPqNdcfwZsO8INezbxJ08QCs/xVug==",
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.25.tgz",
+      "integrity": "sha512-bi2pM76ChfZ8fOG9OUOFovmPmMbUpUAETZar9/NHCOEHtUKV/5K1am/1hCrRmvkeB62UZah9jWSKv1kk61bLpA==",
       "peer": true,
       "requires": {
-        "@appium/base-driver": "^9.4.1",
-        "@appium/support": "^4.1.8"
+        "@appium/base-driver": "^9.4.4",
+        "@appium/support": "^4.1.11"
       }
     },
     "@appium/docutils": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-0.4.11.tgz",
-      "integrity": "sha512-U2X0IOnuaaDvFsFulMlkPTYBbLD/UTMkRKYbiiztWyj9pBpvUSeTx60DM8dYCWVzTCl2ewRbVUPeUWQF04/q2A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.1.tgz",
+      "integrity": "sha512-6G0WlosgQ3+S3WLc66GRVGkxeKpMmdmKIcBZTkPt73yNSV5Klu7FLUhEQAKP/hmVorEYs7GqtD6HH6KP7xkSAw==",
       "peer": true,
       "requires": {
-        "@appium/support": "^4.1.8",
+        "@appium/support": "^4.1.11",
         "@appium/tsconfig": "^0.x",
-        "@appium/typedoc-plugin-appium": "^0.x",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
-        "@types/which": "3.0.0",
+        "@types/which": "3.0.3",
         "chalk": "4.1.2",
         "consola": "2.15.3",
         "diff": "5.1.0",
         "figures": "3.2.0",
-        "find-up": "5.0.0",
         "json5": "2.2.3",
         "lilconfig": "2.1.0",
         "lodash": "4.17.21",
@@ -5598,110 +5485,58 @@
         "read-pkg": "5.2.0",
         "semver": "7.5.4",
         "source-map-support": "0.5.21",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
-        "typedoc": "0.23.28",
-        "typedoc-plugin-markdown": "3.14.0",
-        "typedoc-plugin-resolve-crossmodule-references": "0.3.3",
-        "typescript": "5.0.4",
-        "yaml": "2.3.3",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
+        "typescript": "5.2.2",
+        "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
       },
       "dependencies": {
-        "@appium/typedoc-plugin-appium": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/@appium/typedoc-plugin-appium/-/typedoc-plugin-appium-0.6.6.tgz",
-          "integrity": "sha512-sZwhveCtUti2QPAhHWysE8IJVyT9KLUwLxXUBnvDjamEm8cuJmqQDDW9nPgv6iiw1bz9ankv/VLYI8egIpTl6g==",
-          "peer": true,
-          "requires": {
-            "handlebars": "4.7.8",
-            "lodash": "4.17.21",
-            "pluralize": "8.0.0",
-            "type-fest": "3.13.1"
-          }
-        },
-        "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "typedoc": {
-          "version": "0.23.28",
-          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-          "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-          "peer": true,
-          "requires": {
-            "lunr": "^2.3.9",
-            "marked": "^4.2.12",
-            "minimatch": "^7.1.3",
-            "shiki": "^0.14.1"
-          }
-        },
-        "typedoc-plugin-markdown": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
-          "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
-          "peer": true,
-          "requires": {
-            "handlebars": "^4.7.7"
-          }
-        },
-        "typedoc-plugin-resolve-crossmodule-references": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/typedoc-plugin-resolve-crossmodule-references/-/typedoc-plugin-resolve-crossmodule-references-0.3.3.tgz",
-          "integrity": "sha512-ZWWBy2WR8z9a6iXYGlyB3KrpV+JDdZv1mndYU6Eh6mInrfMCrQJi3Y5K9ihMBfuaBGB//le1nEmQLgzU3IO+dw==",
-          "peer": true,
-          "requires": {}
-        },
         "typescript": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
           "peer": true
         }
       }
     },
     "@appium/schema": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.4.1.tgz",
-      "integrity": "sha512-tM2y7GQukExrTdm7fjSe4yA8DA+ZCY5gO5O6YciNmQ0vYZkMFWvjmW0uEzyzJ5kuXMLFzBKFG3Sx/YgoL5gO2A==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.5.0.tgz",
+      "integrity": "sha512-HFed9HtFU6+kLdVyp/xpS/Wfcge8PuMS37LJVShviT6OuzHOYvNFx1/y8+KMa/l0Npvll5eafdfHmUsWlRnUAA==",
       "requires": {
-        "@types/json-schema": "7.0.14",
+        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       }
     },
     "@appium/support": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-4.1.8.tgz",
-      "integrity": "sha512-bdVevgZecnLmddNH40X02rtJCimSsONWyU65Eq0vFemzcgpSpUuxl6LX3EXVvHMl1jNkkEVIh3G98SxFd17CTw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-4.1.11.tgz",
+      "integrity": "sha512-d6Ujgn5IDlzmepI2i41Z3FexuhipZ2DE2omadNCJRMBlf0dd5cXW54WQjsS/5GI1S9c++/9Mk0aEHl/6RQcOpw==",
       "requires": {
         "@appium/tsconfig": "^0.x",
-        "@appium/types": "^0.14.1",
+        "@appium/types": "^0.15.0",
         "@colors/colors": "1.6.0",
-        "@types/archiver": "5.3.4",
-        "@types/base64-stream": "1.0.4",
-        "@types/find-root": "1.1.3",
-        "@types/jsftp": "2.1.4",
-        "@types/klaw": "3.0.5",
-        "@types/lockfile": "1.0.3",
-        "@types/mv": "2.1.3",
-        "@types/ncp": "2.0.7",
-        "@types/npmlog": "4.1.5",
-        "@types/pluralize": "0.0.32",
-        "@types/semver": "7.5.4",
-        "@types/shell-quote": "1.7.3",
-        "@types/supports-color": "8.1.2",
-        "@types/teen_process": "2.0.1",
-        "@types/uuid": "9.0.6",
-        "@types/which": "3.0.0",
+        "@types/archiver": "6.0.2",
+        "@types/base64-stream": "1.0.5",
+        "@types/find-root": "1.1.4",
+        "@types/jsftp": "2.1.5",
+        "@types/klaw": "3.0.6",
+        "@types/lockfile": "1.0.4",
+        "@types/mv": "2.1.4",
+        "@types/ncp": "2.0.8",
+        "@types/npmlog": "7.0.0",
+        "@types/pluralize": "0.0.33",
+        "@types/semver": "7.5.6",
+        "@types/shell-quote": "1.7.5",
+        "@types/supports-color": "8.1.3",
+        "@types/teen_process": "2.0.4",
+        "@types/uuid": "9.0.7",
+        "@types/which": "3.0.3",
         "archiver": "6.0.1",
-        "axios": "1.5.1",
+        "axios": "1.6.2",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
@@ -5730,8 +5565,8 @@
         "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
         "uuid": "9.0.1",
         "which": "4.0.0",
         "yauzl": "2.10.0"
@@ -5746,16 +5581,16 @@
       }
     },
     "@appium/types": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.14.1.tgz",
-      "integrity": "sha512-dhZOMQ4Bi26HXr3m7cw+GNK5IUZRieGqpEAH2FvaCgOya0i5pN/5DF4dHtvY+gdr2/vhHW87/Df5ucOj0wSzMA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-7Ht9ZdvcgBHc0ecttIlfFSMbVmKNL5YRX05BVCBakArWghN97xGRJ5VoUwgEeR8VE+iK0m+3R1p0/7HIxyqRJg==",
       "requires": {
-        "@appium/schema": "^0.4.1",
+        "@appium/schema": "^0.5.0",
         "@appium/tsconfig": "^0.x",
-        "@types/express": "4.17.20",
-        "@types/npmlog": "4.1.5",
-        "@types/ws": "8.5.8",
-        "type-fest": "3.13.1"
+        "@types/express": "4.17.21",
+        "@types/npmlog": "7.0.0",
+        "@types/ws": "8.5.10",
+        "type-fest": "4.8.3"
       }
     },
     "@babel/code-frame": {
@@ -5809,14 +5644,6 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      }
-    },
     "@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -5843,6 +5670,36 @@
         "@dlenroc/roku-dom": "^1.0.0",
         "@dlenroc/roku-ecp": "^1.0.0",
         "@dlenroc/roku-odc": "^1.0.0"
+      },
+      "dependencies": {
+        "@dlenroc/roku-developer-server": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-1.0.2.tgz",
+          "integrity": "sha512-vNUWEi08smVJKvrWeE4FJUSS7oy6vcWPxHPVLx5Uj3H+OzLFd9MlMr6NUaO9cr9JPwKeF1R0U3vnaUWFCZQ7lw==",
+          "requires": {
+            "digest-header": "^1.1.0",
+            "form-data": "^4.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "@dlenroc/roku-ecp": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-1.2.2.tgz",
+          "integrity": "sha512-KbyUk3TTE5qEbrBkVZPukfIX5k6/E5msUj5eSm4SSC5AVjHXBHewQYQiXD9kiPh9RykOmnplOhJfFnHT3BlDzw==",
+          "requires": {
+            "fast-xml-parser": "^4.0.3",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "@dlenroc/roku-odc": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-1.4.3.tgz",
+          "integrity": "sha512-P8l4hdlzLKbXt0neQA8RQ+tvNHEy+0nBEP76ecWT4wU2tOsuWThS19yEImkTPBAHkXXAjyAtdvxiEKkKGGWcSg==",
+          "requires": {
+            "jszip": "^3.7.1",
+            "node-fetch": "^2.6.7"
+          }
+        }
       }
     },
     "@dlenroc/roku-debug-server": {
@@ -5851,13 +5708,11 @@
       "integrity": "sha512-siMQDAJveq2Nl+8sZyIkaYD8+nYaoHfLiFME6wWGDuQDrnD7ctb7KzZZrLjNFg0OHEEGlmAZomOc/g8mCAGJ0g=="
     },
     "@dlenroc/roku-developer-server": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-1.0.2.tgz",
-      "integrity": "sha512-vNUWEi08smVJKvrWeE4FJUSS7oy6vcWPxHPVLx5Uj3H+OzLFd9MlMr6NUaO9cr9JPwKeF1R0U3vnaUWFCZQ7lw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-developer-server/-/roku-developer-server-2.0.0.tgz",
+      "integrity": "sha512-9if2Y4mBjs1yrrbz4o6LZTKkwVcbCppgS0aZiY7KW90zgsYE/8z415Rw8BEwkqGeJ+fQ/F6B8oDuPcAgJ0gntA==",
       "requires": {
-        "digest-header": "^1.1.0",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7"
+        "digest-header": "^1.1.0"
       }
     },
     "@dlenroc/roku-dom": {
@@ -5872,21 +5727,19 @@
       }
     },
     "@dlenroc/roku-ecp": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-1.2.2.tgz",
-      "integrity": "sha512-KbyUk3TTE5qEbrBkVZPukfIX5k6/E5msUj5eSm4SSC5AVjHXBHewQYQiXD9kiPh9RykOmnplOhJfFnHT3BlDzw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-2.0.0.tgz",
+      "integrity": "sha512-i2Zbkyd1eevXgkW9nGfF7GWKwXxDwlj3ADXK5Lg3l1HQCxYB0+bvYoK9Jl26OpaKoY5Xwt73kZj6hDLRB9HIRw==",
       "requires": {
-        "fast-xml-parser": "^4.0.3",
-        "node-fetch": "^2.6.7"
+        "fast-xml-parser": "^4.3.2"
       }
     },
     "@dlenroc/roku-odc": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-1.4.3.tgz",
-      "integrity": "sha512-P8l4hdlzLKbXt0neQA8RQ+tvNHEy+0nBEP76ecWT4wU2tOsuWThS19yEImkTPBAHkXXAjyAtdvxiEKkKGGWcSg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.0.tgz",
+      "integrity": "sha512-SDsDhub5R5cyr1cwT5z5P8RO39j1Y3Vgt8gjx2uYkFvV4MieN5XgNWwsNFQ1jc0GUedyDJSe40kItGAgoLdEVw==",
       "requires": {
-        "jszip": "^3.7.1",
-        "node-fetch": "^2.6.7"
+        "jszip": "^3.10.1"
       }
     },
     "@isaacs/cliui": {
@@ -5993,9 +5846,9 @@
       "optional": true
     },
     "@sidvind/better-ajv-errors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz",
-      "integrity": "sha512-JuIb009FhHuL9priFBho2kv7QmZOydj0LgYvj+h1t0mMCmhM/YmQNRlJR5wVtBZya6wrVFK5Hi5TIbv5BKEx7w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.3.tgz",
+      "integrity": "sha512-lWuod/rh7Xz5uXiEGSfm2Sd5PG7K/6yJfoAZVqzsEswjPJhUz15R7Gn/o8RczA041QS15hBd/BCSeu9vwPArkA==",
       "peer": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
@@ -6026,70 +5879,70 @@
       "dev": true
     },
     "@types/archiver": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.4.tgz",
-      "integrity": "sha512-Lj7fLBIMwYFgViVVZHEdExZC3lVYsl+QL0VmdNdIzGZH544jHveYWij6qdnBgJQDnR7pMKliN9z2cPZFEbhyPw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.2.tgz",
+      "integrity": "sha512-KmROQqbQzKGuaAbmK+ZcytkJ51+YqDa7NmbXjmtC5YBLSyQYo21YaUnQ3HbaPFKL1ooo6RQ6OPYPIDyxfpDDXw==",
       "requires": {
         "@types/readdir-glob": "*"
       }
     },
     "@types/argparse": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.12.tgz",
-      "integrity": "sha512-Qt/6lHaSI+idkJKKTixUTm6q1yjm7EE6ZpsKLkJIHQl7NLAX7lMZRFGAEU8kxaWur3N6L2UE7/U7QR46Isi3vg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.14.tgz",
+      "integrity": "sha512-jJ6NMs9rXQ0rsqNt3TL4Elcwhd6wygo3lJOVoiHzURD34vsCcAlw443uGu4PXTtEmMF7sYKoadTCLXNmuJuQGw==",
       "peer": true
     },
     "@types/async-lock": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.1.tgz",
-      "integrity": "sha512-tpYc9kp2I8eI6qcDWtD2023jIlJYz6030qR1S5WhRbTK/JJcYdJ8fb2dRKPRgqioxcPZfTPmzl/PemHIPCrA9g=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw=="
     },
     "@types/base-64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.1.tgz",
-      "integrity": "sha512-syGYQWNlO2yyGJjyP9i3eZeHZN+QS3V11EnsVwCiYgOQXMmQNAIgVpFsZ146R+o3l9ltB+KEVKsPW8RCyq2EAw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
+      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
       "dev": true
     },
     "@types/base64-stream": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.4.tgz",
-      "integrity": "sha512-uIbi6oqvsS9Rw4qtPh1NFHFNL3KnpyScxU/63GEIP4PonSuejuxkccKPPX4KAAVYl2pwMH6BNQKg1XLfxagfJQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.5.tgz",
+      "integrity": "sha512-gXuo/a7pQ1EXlR5ksM2MccBLl6UUgAgnzR01r/QoHnkaSNinmzSdaGcCq5NAxn72dZ5A1zNYQIl+J9hPsBgBrA==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/bluebird": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.41.tgz",
-      "integrity": "sha512-/OT2UoYPu2fqGNS85UYUx0Ke8Zd/vM0/Au0JqLInTprkRO0NexYe7qAUkDsjhsO3BKHI14wX/UhN5SUaoFVDUQ=="
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
+      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A=="
     },
     "@types/body-parser": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
-      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "@types/connect": {
-      "version": "3.4.37",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
-      "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/cssesc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cssesc/-/cssesc-3.0.1.tgz",
-      "integrity": "sha512-YBjVYODTD7T/FN8UexqZmrrt2TPDjwUV+VidICyZda0f4o9O9YFH58KUbpD2br5xGdA5/+hKoZFQW0K6ijrGMg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cssesc/-/cssesc-3.0.2.tgz",
+      "integrity": "sha512-Qii6nTRktvtI380EloxH/V7MwgrYxkPgBI+NklUjQuhzgAd1AqT3QDJd+eD+0doRADgfwvtagLRo7JFa7aMHXg==",
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
-      "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -6098,9 +5951,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.39",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
-      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
+      "version": "4.17.41",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -6109,80 +5962,85 @@
       }
     },
     "@types/fancy-log": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-2.0.1.tgz",
-      "integrity": "sha512-XUkwOVjG0StZTzw32vHfTGSXmE02/mMfM1Zqouwq2h8rrV/TwLb5TTvePaXO1YqY5yi7u90GsvoRLMqXInaK9Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-2.0.2.tgz",
+      "integrity": "sha512-SXVJvqWjsl90VwBfp7w4iQ0iO+vxAjQImglcpwbV9GkqNoUD5/p9Wsgetl40F1WL7pzWFN/eZPTF1g5FZXJsIw==",
       "peer": true
     },
     "@types/find-root": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.3.tgz",
-      "integrity": "sha512-dRJIphFmChb6NoCntSYgC2eCdXcdIXm9/qqV0Mtp8HcyINWK7YZkaLlJQO9TB2rDTo/y35veiCy68IxNV05VMg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.4.tgz",
+      "integrity": "sha512-2EXK/+gVhVgtt4JqThbEncORvpYJKzi9tQGmI3EkU2jTgMzQsrPm/hbd5xe5uPdeFzIW5gh2PRvvPjaUsI8vpg=="
     },
     "@types/http-errors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
-      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/jsftp": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.4.tgz",
-      "integrity": "sha512-AQ5bGKbC5xZwLuz9xPnzp811tm0c4MqThAdXVUZstkv+sz3qyM5Eg4krlqkzvf6sTU8Il5RwVTSdYqNW4oQCxw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.5.tgz",
+      "integrity": "sha512-g2W6f06wXWVYZw3f/z/N5VHRK69kb1nFaNcRnxs6YxwLph+G7ebd0+Aobd3jWu43oZuyHgycpJZPn+YdIU6qRw==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/klaw": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.5.tgz",
-      "integrity": "sha512-sX8M64GwQbEhPA4GrOUYEl/0Cc9oz5Effoaj43B4o3bsVwskxEipparp8tI1E6lhs2s1R1u/0KeNvf/9OR1cAA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.6.tgz",
+      "integrity": "sha512-BErW5TrTz4nzt/c3VRGf0Bug4JyQJ1o807F4mAfXfvOzFZ8SKgFeHJ0T28Y1KtqlMEB+cUgN7S7CsyQDQ/qxqg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha512-p0ZFzoiL0B9MbNaanUV4u86E9k9PaZdhahiKfsOqj30v/vtNz2NyZFp/VJpVp6E7Iy5a9lXozZmnjm7FbtoKnw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ=="
     },
     "@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "@types/method-override": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-0.0.34.tgz",
-      "integrity": "sha512-3Ga3AZNaHASSMIWM1MxwJL47x6pB/U5ARYNgMnTNYvLDO9p5ZkgTn+Oe1AKiVxat457QN99OXh/zI+BfnrbNxA==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-0.0.35.tgz",
+      "integrity": "sha512-HdhM5xiIV8fwsZ3B8e9IKWJOqEgmXXBJ/qQzhs5Z8idjsszqEX4j/7/QAcso27ArZ1tSBXg2XMlI1cIHAsCTXA==",
       "requires": {
         "@types/express": "*"
       }
     },
     "@types/mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/mv": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.3.tgz",
-      "integrity": "sha512-RQ5XrCe7RWGw3K5bsUpeURtqkhP0/hA/hmUz38Uc2J9nRirkJNmcSumHSK7SNbGw62vuIs3x0sy4hGwoXFdLXQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.4.tgz",
+      "integrity": "sha512-MgEHBpXnQo44Q43j8G0Bvp/Yi8LYbC8hxKrRFMgDEDZMmzDKZLgiyMWtW49B37ko+QupgZ3G5rtPUnOGe5ixLw=="
     },
     "@types/ncp": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.7.tgz",
-      "integrity": "sha512-Ns28Jr+Me6DeWolxrh6VtjLKWjUxwpnc9/8RLCzvsFvod28bwsI1DOuXrNYs8YExDW7acc/JnZ/vnGe1FUS5Kw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.8.tgz",
+      "integrity": "sha512-pLNWVLCVWBLVM4F2OPjjK6FWFtByFKD7LhHryF+MbVLws7ENj09mKxRFlhkGPOXfJuaBAG+2iADKJsZwnAbYDw==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "17.0.40"
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.3",
@@ -6190,62 +6048,62 @@
       "integrity": "sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg=="
     },
     "@types/npmlog": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.5.tgz",
-      "integrity": "sha512-Fl3TEbwPoR7V1z6CMJ18whXOUkOYqF5eCkGKTir2VuevdLYUmcwj9mQdvXzuY0oagZBbsy0J7df41jn+ZcwGRA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
+      "integrity": "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/pluralize": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.32.tgz",
-      "integrity": "sha512-exDkoRIkWJlbRDRmtYDbI3ZUE28HwBwHe5VKn4mvpvMW7qIRDHO6URItErBsBSX7J8/PrDLSOHCcbUMFXwA6CA=="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
+      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg=="
     },
     "@types/qs": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
-      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg=="
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
     "@types/range-parser": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
-      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-trCChHpWDGCJCUPJRwD62eapW4KOru6h4S7n9KUIESaxhyBM/2Jh20P3XrFRQQ6Df78E/rq2DbUCVZlI8CXPnA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "@types/send": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
-      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "@types/serve-favicon": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.6.tgz",
-      "integrity": "sha512-Qm/Fct+DtjepE85kOAvPtI/OkB8gPZkBuVhKSv3Xpmy3J7zboVdUspGZOZJVVDa/U7ypaCt2cF3Xm5A9gqUvmg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.7.tgz",
+      "integrity": "sha512-z9TNUQXdQ+W/OJMP1e3KOYUZ99qJS4+ZfFOIrPGImcayqKoyifbJSEFkVq1MCKBbqjMZpjPj3B5ilrQAR2+TOw==",
       "requires": {
         "@types/express": "*"
       }
     },
     "@types/serve-static": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
-      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -6253,19 +6111,19 @@
       }
     },
     "@types/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-CeYcQaOnluyKPHJTuJmaH9RDJEQSVxGMVf2EZab3chpA8sI65FB19t0x3JlS37NbxL+TUottk9pMypMJQcfhIw=="
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="
     },
     "@types/supports-color": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.2.tgz",
-      "integrity": "sha512-nhs1D8NjNueBqRBhBTsc81g90g7VBD4wnMTMy9oP+QIldHuJkE655QTL2D1jkj3LyCd+Q5Y69oOpfxN1l0eCMA=="
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
+      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg=="
     },
     "@types/teen_process": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.1.tgz",
-      "integrity": "sha512-hSLCkcQa9Ok1Mg0c1NbCJh9km6Gynj/7mHF2wQQNiiugMGkbhGfToZwEW78XRBnlw3784B6C8nsYnVeiU9bEwg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.4.tgz",
+      "integrity": "sha512-AJT0syZovEDa4j17szoRJX5BE2RxD3FVp6SownH43mF16TPnsV0zhtsvFGlgs5QkgsNpoooNnF+HjMow7Jd3jA==",
       "requires": {
         "@types/node": "*"
       }
@@ -6277,14 +6135,14 @@
       "peer": true
     },
     "@types/uuid": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
-      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
     },
     "@types/which": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g=="
     },
     "@types/wrap-ansi": {
       "version": "3.0.0",
@@ -6293,9 +6151,9 @@
       "peer": true
     },
     "@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "requires": {
         "@types/node": "*"
       }
@@ -6374,12 +6232,6 @@
     "ansi-regex": {
       "version": "5.0.1"
     },
-    "ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "peer": true
-    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6389,30 +6241,30 @@
       }
     },
     "appium": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-2.2.1.tgz",
-      "integrity": "sha512-9W7QEJEUtRw9czYFaZZT6dBosOIDHbfK4MdCnCLOsvul7nlllrHr3k9TpLbz8SNuFZMDKNaqGE6KDUTez2DN8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/appium/-/appium-2.3.0.tgz",
+      "integrity": "sha512-uhLh+Glfr31vt3R6lnE6+LcBdxDArGKV1FRf072K6DZlEhz94aniRpMwKuMaQ76jfoF3BqWFmEJRIQL+2eRUKQ==",
       "peer": true,
       "requires": {
-        "@appium/base-driver": "^9.4.1",
-        "@appium/base-plugin": "^2.2.22",
-        "@appium/docutils": "^0.4.11",
-        "@appium/schema": "^0.4.1",
-        "@appium/support": "^4.1.8",
-        "@appium/types": "^0.14.1",
-        "@sidvind/better-ajv-errors": "2.1.0",
-        "@types/argparse": "2.0.12",
-        "@types/bluebird": "3.5.41",
-        "@types/fancy-log": "2.0.1",
-        "@types/semver": "7.5.4",
-        "@types/teen_process": "2.0.1",
+        "@appium/base-driver": "^9.4.4",
+        "@appium/base-plugin": "^2.2.25",
+        "@appium/docutils": "^1.0.1",
+        "@appium/schema": "^0.5.0",
+        "@appium/support": "^4.1.11",
+        "@appium/types": "^0.15.0",
+        "@sidvind/better-ajv-errors": "2.1.3",
+        "@types/argparse": "2.0.14",
+        "@types/bluebird": "3.5.42",
+        "@types/fancy-log": "2.0.2",
+        "@types/semver": "7.5.6",
+        "@types/teen_process": "2.0.4",
         "@types/wrap-ansi": "3.0.0",
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
         "argparse": "2.0.1",
         "async-lock": "1.4.0",
-        "asyncbox": "2.9.4",
-        "axios": "1.5.1",
+        "asyncbox": "3.0.0",
+        "axios": "1.6.2",
         "bluebird": "3.7.2",
         "cross-env": "7.0.3",
         "find-up": "5.0.0",
@@ -6424,26 +6276,13 @@
         "resolve-from": "5.0.0",
         "semver": "7.5.4",
         "source-map-support": "0.5.21",
-        "teen_process": "2.0.50",
-        "type-fest": "3.13.1",
+        "teen_process": "2.1.1",
+        "type-fest": "4.8.3",
         "winston": "3.11.0",
         "wrap-ansi": "7.0.0",
-        "yaml": "2.3.3"
+        "yaml": "2.3.4"
       },
       "dependencies": {
-        "asyncbox": {
-          "version": "2.9.4",
-          "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.9.4.tgz",
-          "integrity": "sha512-TCuA73K6Gvn+5tFGsWf4jc+PsR9RmYXw/AF0mv+CRB3VhHLjqHh/w9gPvYILnV0RcRFfjADHtzZexpxWlsP3Tg==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "@types/bluebird": "^3.5.37",
-            "bluebird": "^3.5.1",
-            "lodash": "^4.17.4",
-            "source-map-support": "^0.5.5"
-          }
-        },
         "wrap-ansi": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6573,9 +6412,9 @@
       "version": "0.4.0"
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -7284,9 +7123,9 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-xml-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
-      "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -7526,19 +7365,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "optional": true
-    },
-    "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "peer": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -7812,12 +7638,6 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "peer": true
     },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "peer": true
-    },
     "jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -7986,15 +7806,9 @@
       }
     },
     "lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
-    },
-    "lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "peer": true
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -8015,12 +7829,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "peer": true
-    },
-    "marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "peer": true
     },
     "media-typer": {
@@ -8196,12 +8004,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
     },
     "node-abi": {
       "version": "3.51.0",
@@ -8628,11 +8430,6 @@
         }
       }
     },
-    "regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8705,6 +8502,78 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        }
+      }
+    },
+    "roku-dom": {
+      "version": "npm:@dlenroc/roku-dom@2.0.0",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-dom/-/roku-dom-2.0.0.tgz",
+      "integrity": "sha512-HG9zRDMqBQF9rMku7WW4LpBYVPsRRcERRi2rPX94luTy5iC3yK/vBSyWMdcNwkdsI4llmVWDMIqDaA529ggrDg==",
+      "requires": {
+        "css-select": "^5.1.0",
+        "css-select-base-adapter": "^0.1.1",
+        "libxmljs2": "^0.33.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+          "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.1.0",
+            "domhandler": "^5.0.2",
+            "domutils": "^3.0.1",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "libxmljs2": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+          "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
+          "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.11",
+            "bindings": "~1.5.0",
+            "nan": "~2.18.0"
+          }
+        },
+        "nan": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+          "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         }
       }
     },
@@ -8847,18 +8716,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
-    },
-    "shiki": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.5.tgz",
-      "integrity": "sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==",
-      "peer": true,
-      "requires": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
-      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -9140,14 +8997,14 @@
       }
     },
     "teen_process": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.0.50.tgz",
-      "integrity": "sha512-DDppkV654MHUqIrZe2M4FK4NmTKxHHHlr/2M9yE0VrsY3iDUsZFbCIBzVEZ9fQ47Cem4JLtUp9ml4FGp3vR+Uw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.1.tgz",
+      "integrity": "sha512-PIX+PyH6h52uJeGpXfjLdIBRim5pPkJTkO/PPeLCa5NlofqlasTjcvNUUYo6XurnxSTl0o17sBzIrVoXNuqwGg==",
       "requires": {
-        "bluebird": "3.7.2",
-        "lodash": "4.17.21",
-        "shell-quote": "1.8.1",
-        "source-map-support": "0.5.21"
+        "bluebird": "^3.7.2",
+        "lodash": "^4.17.21",
+        "shell-quote": "^1.8.1",
+        "source-map-support": "^0.x"
       }
     },
     "text-hex": {
@@ -9223,9 +9080,9 @@
       }
     },
     "type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
+      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -9237,16 +9094,14 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
     },
-    "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "optional": true,
-      "peer": true
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unorm": {
       "version": "1.6.0",
@@ -9299,18 +9154,6 @@
     },
     "vary": {
       "version": "1.1.2"
-    },
-    "vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "peer": true
-    },
-    "vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "peer": true
     },
     "wbuf": {
       "version": "1.7.3",
@@ -9388,12 +9231,6 @@
         "triple-beam": "^1.3.0"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "peer": true
-    },
     "wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -9467,9 +9304,9 @@
       "version": "4.0.0"
     },
     "yaml": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "peer": true
     },
     "yargs": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -481,6 +481,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/@dlenroc/roku-dom/node_modules/libxmljs2": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.10",
+        "bindings": "~1.5.0",
+        "nan": "~2.17.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@dlenroc/roku-dom/node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "node_modules/@dlenroc/roku-ecp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dlenroc/roku-ecp/-/roku-ecp-2.0.0.tgz",
@@ -3094,20 +3113,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/libxmljs2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
-      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "bindings": "~1.5.0",
-        "nan": "~2.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/lie": {
       "version": "3.3.0",
       "license": "MIT",
@@ -3451,11 +3456,6 @@
       "bin": {
         "rimraf": "bin.js"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
@@ -4244,6 +4244,25 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/roku-dom/node_modules/libxmljs2": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.10",
+        "bindings": "~1.5.0",
+        "nan": "~2.17.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/roku-dom/node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5704,7 +5723,24 @@
         "@dlenroc/roku": "^1.2.0",
         "css-select": "^4.3.0",
         "css-select-base-adapter": "^0.1.1",
-        "libxmljs2": "0.33.0"
+        "libxmljs2": "0.32.0"
+      },
+      "dependencies": {
+        "libxmljs2": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+          "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+          "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.10",
+            "bindings": "~1.5.0",
+            "nan": "~2.17.0"
+          }
+        },
+        "nan": {
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+        }
       }
     },
     "@dlenroc/roku-ecp": {
@@ -7701,16 +7737,6 @@
         }
       }
     },
-    "libxmljs2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
-      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
-      "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "bindings": "~1.5.0",
-        "nan": "~2.18.0"
-      }
-    },
     "lie": {
       "version": "3.3.0",
       "requires": {
@@ -7964,11 +7990,6 @@
           }
         }
       }
-    },
-    "nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -8493,7 +8514,7 @@
       "requires": {
         "css-select": "^5.1.0",
         "css-select-base-adapter": "^0.1.1",
-        "libxmljs2": "0.33.0"
+        "libxmljs2": "0.32.0"
       },
       "dependencies": {
         "css-select": {
@@ -8540,6 +8561,21 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
           "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "libxmljs2": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+          "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
+          "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.10",
+            "bindings": "~1.5.0",
+            "nan": "~2.17.0"
+          }
+        },
+        "nan": {
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "@dlenroc/roku": "^1.2.0",
         "@dlenroc/roku-developer-server": "^2.0.0",
         "@dlenroc/roku-ecp": "^2.0.0",
-        "@dlenroc/roku-odc": "^2.0.0",
+        "@dlenroc/roku-odc": "^2.0.1",
         "asyncbox": "^3.0.0",
         "base-64": "^1.0.0",
         "cssesc": "^3.0.0",
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@dlenroc/roku-odc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.0.tgz",
-      "integrity": "sha512-SDsDhub5R5cyr1cwT5z5P8RO39j1Y3Vgt8gjx2uYkFvV4MieN5XgNWwsNFQ1jc0GUedyDJSe40kItGAgoLdEVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.1.tgz",
+      "integrity": "sha512-iiewFFH6g8/CccVPIPb28smfEAG7tFyeoQc2sPPho+BIFaZY5Feq/Mt9LaM1ZtsfujoNUc6MemYAcXw4iJhj1g==",
       "dependencies": {
         "jszip": "^3.10.1"
       }
@@ -5752,9 +5752,9 @@
       }
     },
     "@dlenroc/roku-odc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.0.tgz",
-      "integrity": "sha512-SDsDhub5R5cyr1cwT5z5P8RO39j1Y3Vgt8gjx2uYkFvV4MieN5XgNWwsNFQ1jc0GUedyDJSe40kItGAgoLdEVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@dlenroc/roku-odc/-/roku-odc-2.0.1.tgz",
+      "integrity": "sha512-iiewFFH6g8/CccVPIPb28smfEAG7tFyeoQc2sPPho+BIFaZY5Feq/Mt9LaM1ZtsfujoNUc6MemYAcXw4iJhj1g==",
       "requires": {
         "jszip": "^3.10.1"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "@types/cssesc": "^3.0.2",
     "typescript": "^5.3.3"
   },
+  "overrides": {
+    "libxmljs2": "0.33.0"
+  },
   "peerDependencies": {
     "appium": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@dlenroc/roku": "^1.2.0",
     "@dlenroc/roku-developer-server": "^2.0.0",
     "@dlenroc/roku-ecp": "^2.0.0",
-    "@dlenroc/roku-odc": "^2.0.0",
+    "@dlenroc/roku-odc": "^2.0.1",
     "asyncbox": "^3.0.0",
     "base-64": "^1.0.0",
     "cssesc": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "libxmljs2": "0.33.0"
+    "libxmljs2": "0.32.0"
   },
   "peerDependencies": {
     "appium": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "driver"
   ],
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
   "scripts": {
@@ -30,22 +30,26 @@
     "mainClass": "Driver"
   },
   "dependencies": {
-    "@appium/base-driver": "^9.4.1",
-    "@appium/support": "^4.1.8",
+    "@appium/base-driver": "^9.4.4",
+    "@appium/support": "^4.1.11",
     "@dlenroc/roku": "^1.2.0",
+    "@dlenroc/roku-developer-server": "^2.0.0",
+    "@dlenroc/roku-ecp": "^2.0.0",
+    "@dlenroc/roku-odc": "^2.0.0",
     "asyncbox": "^3.0.0",
     "base-64": "^1.0.0",
     "cssesc": "^3.0.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "roku-dom": "npm:@dlenroc/roku-dom@^2.0.0"
   },
   "devDependencies": {
-    "@appium/types": "^0.14.1",
+    "@appium/types": "^0.15.0",
     "@tsconfig/node18": "^18.2.2",
-    "@types/base-64": "^1.0.1",
-    "@types/cssesc": "^3.0.1",
-    "typescript": "^5.2.2"
+    "@types/base-64": "^1.0.2",
+    "@types/cssesc": "^3.0.2",
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "appium": "^2.2.1"
+    "appium": "^2.3.0"
   }
 }

--- a/src/CapabilitiesConstraints.ts
+++ b/src/CapabilitiesConstraints.ts
@@ -1,4 +1,4 @@
-import type { Constraints } from "@appium/types";
+import type { Constraints } from '@appium/types';
 
 export const capabilitiesConstraints = {
   app: {

--- a/src/Elements.ts
+++ b/src/Elements.ts
@@ -1,4 +1,3 @@
-
 export const KEYBOARD =
   'substring(name(), string-length(name()) - string-length("Keyboard") + 1) = "Keyboard"' +
   ' or ' +

--- a/src/commands/activateApp.ts
+++ b/src/commands/activateApp.ts
@@ -1,13 +1,20 @@
-import type { AppId, Params } from '@dlenroc/roku';
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
-export async function activateApp(this: Driver, appId: string, options?: unknown): Promise<void> {
-  await this.roku.ecp.launch(appId as AppId, options as Params);
+export async function activateApp(
+  this: Driver,
+  appId: string,
+  options?: unknown
+): Promise<void> {
+  await ecp.launch(this.sdk.ecp, {
+    appId: appId as ecp.AppId,
+    params: options as Record<string, unknown>,
+  });
   await this.waitForCondition({
     error: 'Channel not started',
     condition: async () => {
-      const activeApp = await this.roku.ecp.queryActiveApp();
-      return typeof activeApp.app !== 'string' && activeApp.app.id == appId;
+      const state = await this.queryAppState(appId);
+      return state === 4;
     },
   });
 }

--- a/src/commands/active.ts
+++ b/src/commands/active.ts
@@ -1,10 +1,9 @@
 import { util } from '@appium/support';
 import type { Element } from '@appium/types';
-import base64 from 'base-64';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function active(this: Driver): Promise<Element> {
-  await this.roku.document.render();
-  const focusedElement = this.roku.document.focusedElement;
-  return util.wrapElement(base64.encode(focusedElement.path));
+  await this.document.render();
+  const focusedElement = this.document.focusedElement;
+  return util.wrapElement(Buffer.from(focusedElement.path).toString('base64'));
 }

--- a/src/commands/background.ts
+++ b/src/commands/background.ts
@@ -1,14 +1,18 @@
 /// <reference path='../../types/asyncbox.d.ts'/>
 
 import { errors } from '@appium/base-driver';
+import * as ecp from '@dlenroc/roku-ecp';
 import { longSleep } from 'asyncbox';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function background(this: Driver, seconds: null | number): Promise<void> {
-  const activeApp = await this.roku.ecp.queryActiveApp();
+export async function background(
+  this: Driver,
+  seconds: null | number
+): Promise<void> {
+  const activeApp = await ecp.queryActiveApp(this.sdk.ecp);
   const app = activeApp.app;
 
-  if (typeof app === 'string') {
+  if (!('id' in app)) {
     throw new errors.InvalidArgumentError(`Channel is not running`);
   }
 

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function clear(this: Driver, elementId: string): Promise<void> {
   await this.replaceValue('', elementId);

--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function click(this: Driver, elementId: string): Promise<void> {
   const element = await this.getElement(elementId);

--- a/src/commands/closeApp.ts
+++ b/src/commands/closeApp.ts
@@ -1,12 +1,13 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
 export async function closeApp(this: Driver): Promise<void> {
   await this.waitForCondition({
     error: 'Channel not closed',
     condition: async () => {
-      await this.roku.ecp.keypress('Home');
-      const activeApp = await this.roku.ecp.queryActiveApp();
-      return activeApp.app === 'Roku';
+      await ecp.keypress(this.sdk.ecp, { key: 'Home' });
+      const activeApp = await ecp.queryActiveApp(this.sdk.ecp);
+      return !('id' in activeApp.app);
     },
   });
 }

--- a/src/commands/createSession.ts
+++ b/src/commands/createSession.ts
@@ -1,8 +1,16 @@
 import { BaseDriver } from '@appium/base-driver';
-import type { DefaultCreateSessionResult, DriverData, W3CDriverCaps } from '@appium/types';
+import type {
+  DefaultCreateSessionResult,
+  DriverData,
+  W3CDriverCaps,
+} from '@appium/types';
 import { SDK } from '@dlenroc/roku';
-import type { capabilitiesConstraints as constrains } from '../CapabilitiesConstraints';
-import type { Driver } from '../Driver';
+import { DeveloperServerExecutor } from '@dlenroc/roku-developer-server';
+import { ECPExecutor } from '@dlenroc/roku-ecp';
+import { ODCExecutor } from '@dlenroc/roku-odc';
+import { Document } from 'roku-dom';
+import type { capabilitiesConstraints as constrains } from '../CapabilitiesConstraints.js';
+import type { Driver } from '../Driver.ts';
 
 export async function createSession(
   this: Driver,
@@ -11,11 +19,49 @@ export async function createSession(
   w3cCaps: W3CDriverCaps<typeof constrains>,
   driverData?: DriverData[]
 ): Promise<DefaultCreateSessionResult<typeof constrains>> {
-  const session = BaseDriver.prototype.createSession.call(this, jwpCaps, jwpReqCaps, w3cCaps, driverData);
-  const { app, arguments: args, context, entryPoint, ip, noReset, password, registry, username } = this.opts;
+  const session = BaseDriver.prototype.createSession.call(
+    this,
+    jwpCaps,
+    jwpReqCaps,
+    w3cCaps,
+    driverData
+  );
+  const {
+    app,
+    arguments: args,
+    context,
+    entryPoint,
+    ip,
+    noReset,
+    password,
+    registry,
+    username,
+  } = this.opts;
+
+  this.abortController = new AbortController();
+
+  this.sdk = {
+    developerServer: new DeveloperServerExecutor({
+      signal: this.abortController.signal,
+      address: `http://${ip}`,
+      username: username || 'rokudev',
+      password,
+    }),
+    ecp: new ECPExecutor({
+      signal: this.abortController.signal,
+      address: `http://${ip}:8060`,
+    }),
+    odc: new ODCExecutor({
+      signal: this.abortController.signal,
+      address: `http://${ip}:8061`,
+    }),
+  };
+
+  this.document = new Document(this.sdk);
+  this.document.context = context || 'ECP';
 
   this.roku = new SDK(ip, username || 'rokudev', password);
-  this.roku.document.context = context || 'ECP';
+  this.roku.document = this.document as any;
 
   if (app) {
     await this.installApp(app);

--- a/src/commands/deleteSession.ts
+++ b/src/commands/deleteSession.ts
@@ -1,20 +1,23 @@
 import { BaseDriver } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function deleteSession(this: Driver, sessionId?: string): Promise<void> {
-  await BaseDriver.prototype.deleteSession.call(this, sessionId);
+export async function deleteSession(
+  this: Driver,
+  sessionId?: string
+): Promise<void> {
+  try {
+    await BaseDriver.prototype.deleteSession.call(this, sessionId);
 
-  const { fullReset, noReset } = this.opts;
+    const { fullReset, noReset } = this.opts;
 
-  if (fullReset) {
-    const isInstalled = await this.isAppInstalled('dev');
-
-    if (isInstalled) {
+    if (fullReset) {
       await this.removeApp('dev');
     }
-  }
 
-  if (!noReset) {
-    await this.closeApp();
+    if (!noReset) {
+      await this.closeApp();
+    }
+  } finally {
+    this.abortController.abort('Session deleted');
   }
 }

--- a/src/commands/elementDisplayed.ts
+++ b/src/commands/elementDisplayed.ts
@@ -1,6 +1,9 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function elementDisplayed(this: Driver, elementId: string): Promise<boolean> {
+export async function elementDisplayed(
+  this: Driver,
+  elementId: string
+): Promise<boolean> {
   const element = await this.getElement(elementId);
   return element.isDisplayed;
 }

--- a/src/commands/elementSelected.ts
+++ b/src/commands/elementSelected.ts
@@ -1,6 +1,9 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function elementSelected(this: Driver, elementId: string): Promise<boolean> {
+export async function elementSelected(
+  this: Driver,
+  elementId: string
+): Promise<boolean> {
   const element = await this.getElement(elementId);
   return element.isFocused;
 }

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -1,12 +1,18 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function execute(this: Driver, script: string, args: unknown[]): Promise<unknown> {
+export async function execute(
+  this: Driver,
+  script: string,
+  args: unknown[]
+): Promise<unknown> {
   const [component, method] = script.split(':');
   const roku = this.roku as any;
 
   if (!roku[component]?.[method]) {
-    return new errors.InvalidArgumentError(`Script format must be "<component>:<method_name>"`);
+    return new errors.InvalidArgumentError(
+      `Script format must be "<component>:<method_name>"`
+    );
   }
 
   return roku[component][method](...args);

--- a/src/commands/findElOrEls.ts
+++ b/src/commands/findElOrEls.ts
@@ -1,13 +1,29 @@
 import { errors } from '@appium/base-driver';
 import { util } from '@appium/support';
 import { Element } from '@appium/types';
-import type { Element as RokuElement } from '@dlenroc/roku';
 import base64 from 'base-64';
-import type { Driver } from '../Driver';
+import type { Element as RokuElement } from 'roku-dom';
+import type { Driver } from '../Driver.ts';
 
-export function findElOrEls(strategy: string, selector: string, mult: false, context?: any): Promise<Element>;
-export function findElOrEls(strategy: string, selector: string, mult: true, context?: any): Promise<Element[]>;
-export async function findElOrEls(this: Driver, strategy: string, selector: string, mult: boolean, context: string): Promise<Element | Element[]> {
+export function findElOrEls(
+  strategy: string,
+  selector: string,
+  mult: false,
+  context?: any
+): Promise<Element>;
+export function findElOrEls(
+  strategy: string,
+  selector: string,
+  mult: true,
+  context?: any
+): Promise<Element[]>;
+export async function findElOrEls(
+  this: Driver,
+  strategy: string,
+  selector: string,
+  mult: boolean,
+  context: string
+): Promise<Element | Element[]> {
   if (mult) {
     return findEls.call(this, strategy, selector, context);
   } else {
@@ -15,7 +31,12 @@ export async function findElOrEls(this: Driver, strategy: string, selector: stri
   }
 }
 
-async function findEl(this: Driver, strategy: string, selector: string, context: string): Promise<Element> {
+async function findEl(
+  this: Driver,
+  strategy: string,
+  selector: string,
+  context: string
+): Promise<Element> {
   let element: RokuElement;
 
   if (this.implicitWaitMs) {
@@ -23,7 +44,8 @@ async function findEl(this: Driver, strategy: string, selector: string, context:
     element = await this.retrying({
       timeout: this.implicitWaitMs,
       command: () => this.getElement(strategy, selector, context),
-      validate: (element, error) => !!element || !(error instanceof errors.NoSuchElementError),
+      validate: (element, error) =>
+        !!element || !(error instanceof errors.NoSuchElementError),
     });
   } else {
     element = await this.getElement(strategy, selector, context);
@@ -32,7 +54,12 @@ async function findEl(this: Driver, strategy: string, selector: string, context:
   return util.wrapElement(base64.encode(element.path));
 }
 
-async function findEls(this: Driver, strategy: string, selector: string, context: string): Promise<Element[]> {
+async function findEls(
+  this: Driver,
+  strategy: string,
+  selector: string,
+  context: string
+): Promise<Element[]> {
   let elements: RokuElement[];
 
   if (this.implicitWaitMs) {
@@ -40,11 +67,14 @@ async function findEls(this: Driver, strategy: string, selector: string, context
     elements = await this.retrying({
       timeout: this.implicitWaitMs,
       command: () => this.getElements(strategy, selector, context),
-      validate: (elements, error) => !!error || (Array.isArray(elements) && elements.length > 0),
+      validate: (elements, error) =>
+        !!error || (Array.isArray(elements) && elements.length > 0),
     });
   } else {
     elements = await this.getElements(strategy, selector, context);
   }
 
-  return elements.map((element) => util.wrapElement(base64.encode(element.path)));
+  return elements.map((element) =>
+    util.wrapElement(base64.encode(element.path))
+  );
 }

--- a/src/commands/getAlertText.ts
+++ b/src/commands/getAlertText.ts
@@ -1,11 +1,11 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
-import { DIALOG } from '../Elements';
+import type { Driver } from '../Driver.ts';
+import { DIALOG } from '../Elements.js';
 
 export async function getAlertText(this: Driver): Promise<string | null> {
   if (!(await this.isAlertShown())) {
     throw new errors.NoAlertOpenError(undefined);
   }
 
-  return this.roku.document.xpathSelect(`//*[${DIALOG}]`)!!.text;
+  return this.document.xpathSelect(`//*[${DIALOG}]`).text;
 }

--- a/src/commands/getContexts.ts
+++ b/src/commands/getContexts.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function getContexts(this: Driver): Promise<string[]> {
   return ['ECP', 'ODC'];

--- a/src/commands/getCurrentContext.ts
+++ b/src/commands/getCurrentContext.ts
@@ -1,5 +1,5 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function getCurrentContext(this: Driver): Promise<string | null> {
-  return this.roku.document.context;
+  return this.document.context;
 }

--- a/src/commands/getElementRect.ts
+++ b/src/commands/getElementRect.ts
@@ -1,8 +1,11 @@
 import { errors } from '@appium/base-driver';
 import type { Rect } from '@appium/types';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function getElementRect(this: Driver, elementId: string): Promise<Rect> {
+export async function getElementRect(
+  this: Driver,
+  elementId: string
+): Promise<Rect> {
   const element = await this.getElement(elementId);
 
   if (!element.bounds) {

--- a/src/commands/getName.ts
+++ b/src/commands/getName.ts
@@ -1,6 +1,9 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function getName(this: Driver, elementId: string): Promise<string> {
+export async function getName(
+  this: Driver,
+  elementId: string
+): Promise<string> {
   const element = await this.getElement(elementId);
   return element.tag;
 }

--- a/src/commands/getPageSource.ts
+++ b/src/commands/getPageSource.ts
@@ -1,6 +1,11 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import * as odc from '@dlenroc/roku-odc';
+import type { Driver } from '../Driver.ts';
 
 export async function getPageSource(this: Driver): Promise<string> {
-  await this.roku.document.render();
-  return this.roku.document.toString();
+  if (this.document.context === 'ODC') {
+    return odc.getAppUI(this.sdk.odc);
+  } else {
+    return ecp.queryAppUI(this.sdk.ecp);
+  }
 }

--- a/src/commands/getProperty.ts
+++ b/src/commands/getProperty.ts
@@ -1,6 +1,10 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function getProperty(this: Driver, name: string, elementId: string): Promise<string | null> {
+export async function getProperty(
+  this: Driver,
+  name: string,
+  elementId: string
+): Promise<string | null> {
   const element = await this.getElement(elementId);
   return element.attributes[name];
 }

--- a/src/commands/getScreenshot.ts
+++ b/src/commands/getScreenshot.ts
@@ -1,6 +1,9 @@
-import type { Driver } from '../Driver';
+import * as developerServer from '@dlenroc/roku-developer-server';
+import type { Driver } from '../Driver.ts';
 
 export async function getScreenshot(this: Driver): Promise<string> {
-  const image = await this.roku.developerServer.getScreenshot();
-  return image.toString('base64');
+  const path = await developerServer.takeScreenshot(this.sdk.developerServer);
+  const response = await this.sdk.developerServer.execute(path);
+  // TODO check status
+  return Buffer.from(await response.arrayBuffer()).toString('base64');
 }

--- a/src/commands/getText.ts
+++ b/src/commands/getText.ts
@@ -1,6 +1,9 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function getText(this: Driver, elementId: string): Promise<string> {
+export async function getText(
+  this: Driver,
+  elementId: string
+): Promise<string> {
   const element = await this.getElement(elementId);
   return element.text;
 }

--- a/src/commands/getWindowRect.ts
+++ b/src/commands/getWindowRect.ts
@@ -1,5 +1,5 @@
 import type { Rect } from '@appium/types';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function getWindowRect(this: Driver): Promise<Rect> {
   const element = await this.getElement('xpath', '//@bounds');

--- a/src/commands/hideKeyboard.ts
+++ b/src/commands/hideKeyboard.ts
@@ -1,14 +1,17 @@
-import type { Driver } from '../Driver';
-import { BUTTON, DIALOG, KEYBOARD } from '../Elements';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
+import { BUTTON, DIALOG, KEYBOARD } from '../Elements.js';
 
 export async function hideKeyboard(this: Driver): Promise<boolean> {
   const keyboard = await this.getElement('xpath', `//*[${KEYBOARD}]`);
-  const submitButton = keyboard.xpathSelect(`./ancestor-or-self::*[${DIALOG}]//*[${BUTTON}]`);
+  const submitButton = keyboard.xpathSelect(
+    `./ancestor-or-self::*[${DIALOG}]//*[${BUTTON}]`
+  );
 
   if (submitButton) {
     await submitButton.select();
   } else {
-    await this.roku.ecp.keypress('Enter');
+    await ecp.keypress(this.sdk.ecp, { key: 'Enter' });
   }
 
   await this.waitForCondition({

--- a/src/commands/installApp.ts
+++ b/src/commands/installApp.ts
@@ -1,7 +1,10 @@
 import type { App } from '@dlenroc/roku';
+import * as developerServer from '@dlenroc/roku-developer-server';
+import * as ecp from '@dlenroc/roku-ecp';
+import * as odc from '@dlenroc/roku-odc';
 import { createHash } from 'crypto';
 import { readFile } from 'fs/promises';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function installApp(this: Driver, appPath: string): Promise<void> {
   appPath = await this.helpers.configureApp(appPath, {
@@ -10,7 +13,7 @@ export async function installApp(this: Driver, appPath: string): Promise<void> {
   });
 
   const source = await readFile(appPath);
-  const apps = await this.roku.ecp.queryApps();
+  const apps = await ecp.queryApps(this.sdk.ecp);
   let app: App | undefined = apps.find((app) => app.id === 'dev');
 
   if (app) {
@@ -18,12 +21,24 @@ export async function installApp(this: Driver, appPath: string): Promise<void> {
     const alreadyInstalled = app.name.endsWith(`| ${md5}`);
 
     if (alreadyInstalled) {
-      this.logger.info('Channel is already installed');
+      this.log.info('Channel is already installed');
       return;
     }
   }
 
-  this.logger.info('Install channel');
-  const patchedApp = await this.roku.odc.extend(source);
-  await this.roku.developerServer.install(patchedApp);
+  this.log.info('Install channel');
+  const patchedApp = await odc.inject(source.buffer);
+  await developerServer.installChannel(this.sdk.developerServer, {
+    content: new Uint8Array(patchedApp),
+  });
+
+  await this.waitForCondition({
+    error: 'Channel not started',
+    condition: async () => {
+      const state = await this.queryAppState('dev');
+      return state === 4;
+    },
+  });
+
+  await this.terminateApp('dev');
 }

--- a/src/commands/isAlertShown.ts
+++ b/src/commands/isAlertShown.ts
@@ -1,6 +1,6 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
-import { DIALOG } from '../Elements';
+import type { Driver } from '../Driver.ts';
+import { DIALOG } from '../Elements.js';
 
 export async function isAlertShown(this: Driver): Promise<boolean> {
   try {

--- a/src/commands/isAppInstalled.ts
+++ b/src/commands/isAppInstalled.ts
@@ -1,6 +1,10 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
-export async function isAppInstalled(this: Driver, appId: string): Promise<boolean> {
-  const apps = await this.roku.ecp.queryApps();
+export async function isAppInstalled(
+  this: Driver,
+  appId: string
+): Promise<boolean> {
+  const apps = await ecp.queryApps(this.sdk.ecp);
   return apps.some((app) => app.id == appId);
 }

--- a/src/commands/isKeyboardShown.ts
+++ b/src/commands/isKeyboardShown.ts
@@ -1,6 +1,6 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function isKeyboardShown(this: Driver): Promise<boolean> {
-  await this.roku.document.render();
-  return this.roku.document.isKeyboardShown;
+  await this.document.render();
+  return this.document.isKeyboardShown;
 }

--- a/src/commands/isLocked.ts
+++ b/src/commands/isLocked.ts
@@ -1,6 +1,7 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
 export async function isLocked(this: Driver): Promise<boolean> {
-  const activeApp = await this.roku.ecp.queryActiveApp();
+  const activeApp = await ecp.queryActiveApp(this.sdk.ecp);
   return !!activeApp.screensaver;
 }

--- a/src/commands/launchApp.ts
+++ b/src/commands/launchApp.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function launchApp(this: Driver): Promise<void> {
   await this.activateApp('dev');

--- a/src/commands/postAcceptAlert.ts
+++ b/src/commands/postAcceptAlert.ts
@@ -1,13 +1,13 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
-import { BUTTON, DIALOG } from '../Elements';
+import type { Driver } from '../Driver.ts';
+import { BUTTON, DIALOG } from '../Elements.js';
 
 export async function postAcceptAlert(this: Driver): Promise<void> {
   if (!(await this.isAlertShown())) {
     throw new errors.NoAlertOpenError(undefined);
   }
 
-  const button = this.roku.document.xpathSelect(`//*[${DIALOG}]//*[${BUTTON}]`);
+  const button = this.document.xpathSelect(`//*[${DIALOG}]//*[${BUTTON}]`);
 
   if (!button) {
     throw new errors.InvalidElementStateError('Failed to accept dialog');

--- a/src/commands/postDismissAlert.ts
+++ b/src/commands/postDismissAlert.ts
@@ -1,12 +1,13 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
 export async function postDismissAlert(this: Driver): Promise<void> {
   if (!(await this.isAlertShown())) {
     throw new errors.NoAlertOpenError(undefined);
   }
 
-  await this.roku.ecp.keypress('Back');
+  await ecp.keypress(this.sdk.ecp, { key: 'Back' });
 
   await this.waitForCondition({
     error: 'Dialog is still visible',

--- a/src/commands/pullFile.ts
+++ b/src/commands/pullFile.ts
@@ -1,6 +1,7 @@
-import type { Driver } from '../Driver';
+import * as odc from '@dlenroc/roku-odc';
+import type { Driver } from '../Driver.ts';
 
 export async function pullFile(this: Driver, path: string): Promise<string> {
-  const content = await this.roku.odc.pullFile(path);
-  return content.toString('base64');
+  const content = await odc.pullFile(this.sdk.odc, { path });
+  return Buffer.from(content).toString('base64');
 }

--- a/src/commands/pullFolder.ts
+++ b/src/commands/pullFolder.ts
@@ -1,19 +1,23 @@
+import * as odc from '@dlenroc/roku-odc';
 import JSZip from 'jszip';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function pullFolder(this: Driver, path: string): Promise<string> {
   const root = path;
-  const roku = this.roku;
+  const sdk = this.sdk;
   const zip = new JSZip();
-  const tree = await roku.odc.getFiles(root);
+  const tree = await odc.getFiles(sdk.odc, { path: root });
 
-  await (async function addFilesInZip(currentPath: string, files: any[]): Promise<void> {
+  await (async function addFilesInZip(
+    currentPath: string,
+    files: any[]
+  ): Promise<void> {
     for (const file of files) {
       const path = `${currentPath}/${file.name}`;
       const fullPath = `${root}/${path}`;
 
       if (file.type === 'file') {
-        zip.file(path, await roku.odc.pullFile(fullPath));
+        zip.file(path, await odc.pullFile(sdk.odc, { path: fullPath }));
       }
 
       if (file.type === 'directory') {

--- a/src/commands/pushFile.ts
+++ b/src/commands/pushFile.ts
@@ -1,5 +1,13 @@
-import type { Driver } from '../Driver';
+import * as odc from '@dlenroc/roku-odc';
+import type { Driver } from '../Driver.ts';
 
-export async function pushFile(this: Driver, path: string, data: string): Promise<void> {
-  await this.roku.odc.pushFile(path, Buffer.from(data, 'base64'));
+export async function pushFile(
+  this: Driver,
+  path: string,
+  data: string
+): Promise<void> {
+  await odc.pushFile(this.sdk.odc, {
+    path,
+    content: Buffer.from(data, 'base64').buffer,
+  });
 }

--- a/src/commands/queryAppState.ts
+++ b/src/commands/queryAppState.ts
@@ -1,9 +1,13 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
-export async function queryAppState(this: Driver, appId: string): Promise<0 | 1 | 2 | 3 | 4> {
-  const activeApp = await this.roku.ecp.queryActiveApp();
+export async function queryAppState(
+  this: Driver,
+  appId: string
+): Promise<0 | 1 | 2 | 3 | 4> {
+  const activeApp = await ecp.queryActiveApp(this.sdk.ecp);
 
-  if (typeof activeApp.app !== 'string' && activeApp.app.id == appId) {
+  if ('id' in activeApp.app && activeApp.app.id == appId) {
     // running in background
     if (activeApp.screensaver) {
       return 3;

--- a/src/commands/releaseActions.ts
+++ b/src/commands/releaseActions.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function releaseActions(this: Driver): Promise<void> {
   if (this.pressedKey) {

--- a/src/commands/removeApp.ts
+++ b/src/commands/removeApp.ts
@@ -1,11 +1,12 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import * as developerServer from '@dlenroc/roku-developer-server';
+import type { Driver } from '../Driver.ts';
 
 export async function removeApp(this: Driver, appId: string): Promise<boolean> {
   if (appId !== 'dev') {
     throw new errors.InvalidArgumentError('Only "dev" channel can be removed');
   }
 
-  await this.roku.developerServer.delete();
+  await developerServer.deleteChannel(this.sdk.developerServer);
   return true;
 }

--- a/src/commands/replaceValue.ts
+++ b/src/commands/replaceValue.ts
@@ -1,6 +1,10 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function replaceValue(this: Driver, value: string, elementId: string): Promise<void> {
+export async function replaceValue(
+  this: Driver,
+  value: string,
+  elementId: string
+): Promise<void> {
   const element = await this.getElement(elementId);
   await element.type(value);
 }

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,4 +1,4 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function reset(this: Driver): Promise<void> {
   const { app, arguments: args, entryPoint, registry } = this.opts;

--- a/src/commands/setAlertText.ts
+++ b/src/commands/setAlertText.ts
@@ -1,13 +1,13 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
-import { DIALOG, KEYBOARD } from '../Elements';
+import type { Driver } from '../Driver.ts';
+import { DIALOG, KEYBOARD } from '../Elements.js';
 
 export async function setAlertText(this: Driver, text: string): Promise<void> {
   if (!(await this.isAlertShown())) {
     throw new errors.NoAlertOpenError(undefined);
   }
 
-  const keyboard = this.roku.document.xpathSelect(`//*[${DIALOG}]//*[${KEYBOARD}]`);
+  const keyboard = this.document.xpathSelect(`//*[${DIALOG}]//*[${KEYBOARD}]`);
 
   if (!keyboard) {
     throw new errors.InvalidElementStateError('Keyboard is not present');

--- a/src/commands/setContext.ts
+++ b/src/commands/setContext.ts
@@ -1,5 +1,5 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function setContext(this: Driver, name: string): Promise<void> {
   // appium-desktop requires NATIVE_APP context
@@ -10,8 +10,10 @@ export async function setContext(this: Driver, name: string): Promise<void> {
   const contexts = await this.getContexts();
 
   if (!contexts.includes(name)) {
-    throw new errors.NoSuchContextError(`There is no "${name}" context in [${contexts.join(', ')}]`);
+    throw new errors.NoSuchContextError(
+      `There is no "${name}" context in [${contexts.join(', ')}]`
+    );
   }
 
-  this.roku.document.context = name as any;
+  this.document.context = name as any;
 }

--- a/src/commands/setUrl.ts
+++ b/src/commands/setUrl.ts
@@ -1,7 +1,8 @@
 import { errors } from '@appium/base-driver';
 import type { AppId } from '@dlenroc/roku';
+import * as ecp from '@dlenroc/roku-ecp';
 import { URL } from 'url';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
 export async function setUrl(this: Driver, url: string): Promise<void> {
   const { host, pathname, searchParams } = new URL(url);
@@ -14,9 +15,9 @@ export async function setUrl(this: Driver, url: string): Promise<void> {
 
   switch (host) {
     case 'launch':
-      return await this.roku.ecp.launch(app, params);
+      return await ecp.launch(this.sdk.ecp, { appId: app, params });
     case 'input':
-      return await this.roku.ecp.input(params);
+      return await ecp.input(this.sdk.ecp, params);
     default:
       throw new errors.InvalidArgumentError('Unsupported URL format');
   }

--- a/src/commands/setValue.ts
+++ b/src/commands/setValue.ts
@@ -1,6 +1,10 @@
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function setValue(this: Driver, text: string, elementId: string): Promise<void> {
+export async function setValue(
+  this: Driver,
+  text: string,
+  elementId: string
+): Promise<void> {
   const element = await this.getElement(elementId);
   await element.append(text);
 }

--- a/src/commands/terminateApp.ts
+++ b/src/commands/terminateApp.ts
@@ -1,9 +1,13 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
-export async function terminateApp(this: Driver, appId: string): Promise<boolean> {
-  const activeApp = await this.roku.ecp.queryActiveApp();
+export async function terminateApp(
+  this: Driver,
+  appId: string
+): Promise<boolean> {
+  const activeApp = await ecp.queryActiveApp(this.sdk.ecp);
 
-  if (typeof activeApp.app !== 'string' && activeApp.app.id == appId) {
+  if ('id' in activeApp.app && activeApp.app.id == appId) {
     await this.closeApp();
     return true;
   }

--- a/src/commands/unlock.ts
+++ b/src/commands/unlock.ts
@@ -1,4 +1,5 @@
-import type { Driver } from '../Driver';
+import * as ecp from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
 
 export async function unlock(this: Driver): Promise<void> {
   const isLocked = await this.isLocked();
@@ -7,7 +8,7 @@ export async function unlock(this: Driver): Promise<void> {
     return;
   }
 
-  await this.roku.ecp.keypress('Enter');
+  await ecp.keypress(this.sdk.ecp, { key: 'Enter' });
   await this.waitForCondition({
     error: 'Screensaver is still visible',
     condition: async () => {

--- a/src/commands/updateSetting.ts
+++ b/src/commands/updateSetting.ts
@@ -1,10 +1,16 @@
 import { errors } from '@appium/base-driver';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function updateSetting(this: Driver, prop: unknown, newValue: unknown): Promise<void> {
+export async function updateSetting(
+  this: Driver,
+  prop: unknown,
+  newValue: unknown
+): Promise<void> {
   if (prop === 'elementResponseAttributes') {
     if (typeof newValue !== 'string') {
-      throw new errors.InvalidArgumentError(`The value of "elementResponseAttributes" must be a string.`);
+      throw new errors.InvalidArgumentError(
+        `The value of "elementResponseAttributes" must be a string.`
+      );
     }
 
     if (newValue) {
@@ -25,9 +31,9 @@ export async function updateSetting(this: Driver, prop: unknown, newValue: unkno
         fields[tag].push(attribute);
       }
 
-      this.roku.document.fields = fields;
+      this.document.fields = fields;
     } else {
-      this.roku.document.fields = undefined;
+      this.document.fields = undefined;
     }
   }
 }

--- a/src/helpers/getElement.ts
+++ b/src/helpers/getElement.ts
@@ -1,8 +1,13 @@
 import { errors } from '@appium/base-driver';
-import type { Element } from '@dlenroc/roku';
-import type { Driver } from '../Driver';
+import type { Element } from 'roku-dom';
+import type { Driver } from '../Driver.ts';
 
-export async function getElement(this: Driver, strategy: string, selector?: string, context?: string): Promise<Element> {
+export async function getElement(
+  this: Driver,
+  strategy: string,
+  selector?: string,
+  context?: string
+): Promise<Element> {
   const hasSelector = !!selector;
 
   [strategy, selector] = this.getSelector(strategy, selector);
@@ -13,8 +18,8 @@ export async function getElement(this: Driver, strategy: string, selector?: stri
   if (context) {
     parent = await this.getElement(context);
   } else {
-    await this.roku.document.render();
-    parent = this.roku.document;
+    await this.document.render();
+    parent = this.document;
   }
 
   switch (strategy) {
@@ -28,9 +33,13 @@ export async function getElement(this: Driver, strategy: string, selector?: stri
 
   if (!element) {
     if (hasSelector) {
-      throw new errors.NoSuchElementError(`Unable to locate element: ${selector}`);
+      throw new errors.NoSuchElementError(
+        `Unable to locate element: ${selector}`
+      );
     } else {
-      throw new errors.StaleElementReferenceError(`Unable to locate element: ${selector}`);
+      throw new errors.StaleElementReferenceError(
+        `Unable to locate element: ${selector}`
+      );
     }
   }
 

--- a/src/helpers/getElements.ts
+++ b/src/helpers/getElements.ts
@@ -1,7 +1,12 @@
-import type { Element } from '@dlenroc/roku';
-import type { Driver } from '../Driver';
+import type { Element } from 'roku-dom';
+import type { Driver } from '../Driver.ts';
 
-export async function getElements(this: Driver, strategy: string, selector: string, context?: string): Promise<Element[]> {
+export async function getElements(
+  this: Driver,
+  strategy: string,
+  selector: string,
+  context?: string
+): Promise<Element[]> {
   [strategy, selector] = this.getSelector(strategy, selector);
 
   let parent: Element;
@@ -10,8 +15,8 @@ export async function getElements(this: Driver, strategy: string, selector: stri
   if (context) {
     parent = await this.getElement(context);
   } else {
-    await this.roku.document.render();
-    parent = this.roku.document;
+    await this.document.render();
+    parent = this.document;
   }
 
   switch (strategy) {

--- a/src/helpers/getSelector.ts
+++ b/src/helpers/getSelector.ts
@@ -1,16 +1,23 @@
 import base64 from 'base-64';
 import cssEscape from 'cssesc';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export function getSelector(this: Driver, strategy: string, selector?: string): ['css selector' | 'xpath', string] {
+export function getSelector(
+  this: Driver,
+  strategy: string,
+  selector?: string
+): ['css selector' | 'xpath', string] {
   if (selector === undefined) {
     return ['xpath', base64.decode(strategy)];
   }
 
   switch (strategy) {
     case 'id':
-      const tag = this.roku.document.context === 'ECP' ? 'name' : 'id';
-      return ['css selector', `[${tag}=${cssEscape(selector, { wrap: true })}]`];
+      const tag = this.document.context === 'ECP' ? 'name' : 'id';
+      return [
+        'css selector',
+        `[${tag}=${cssEscape(selector, { wrap: true })}]`,
+      ];
 
     case 'tag name':
       return ['css selector', cssEscape(selector, { isIdentifier: true })];

--- a/src/helpers/retrying.ts
+++ b/src/helpers/retrying.ts
@@ -1,8 +1,15 @@
 import { longSleep } from 'asyncbox';
 import { performance } from 'perf_hooks';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function retrying<Type>(this: Driver, options: { timeout: number; command: () => Promise<Type>; validate: (result?: Type, error?: any) => boolean }): Promise<Type> {
+export async function retrying<Type>(
+  this: Driver,
+  options: {
+    timeout: number;
+    command: () => Promise<Type>;
+    validate: (result?: Type, error?: any) => boolean;
+  }
+): Promise<Type> {
   const duration = 500;
   const endTimestamp = performance.now() + options.timeout;
 

--- a/src/helpers/waitForCondition.ts
+++ b/src/helpers/waitForCondition.ts
@@ -1,13 +1,26 @@
 /// <reference path='../../types/asyncbox.d.ts'/>
 
 import { waitForCondition as wait } from 'asyncbox';
-import type { Driver } from '../Driver';
+import type { Driver } from '../Driver.ts';
 
-export async function waitForCondition(this: Driver, { error, condition, timeout = 5000, interval = 100 }: { error: string | Error; condition: () => any; timeout?: number; interval?: number }): Promise<void> {
+export async function waitForCondition(
+  this: Driver,
+  {
+    error,
+    condition,
+    timeout = 5000,
+    interval = 100,
+  }: {
+    error: string | Error;
+    condition: () => any;
+    timeout?: number;
+    interval?: number;
+  }
+): Promise<void> {
   await wait(condition, {
     error,
     waitMs: timeout,
     intervalMs: interval,
-    logger: this.logger,
+    logger: this.log,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Driver, Driver as default } from './Driver';
+export { Driver, Driver as default } from './Driver.js';


### PR DESCRIPTION
### Changes

- Set [appium@2.3.0](https://www.npmjs.com/package/appium/v/2.3.0) as the minimum supported version to get ESM support.
- Updated to latest version of Roku SDK for internal use.
  - Fixes GH-67 by matching the current `active` behavior with roku automation solution.
  - Fixes GH-66 by showing additional information in errors.
- Updated `getPageSource` to return the page source directly, without parsing using `roku-dom`.
- Fixed clearing/setting state and passing launch arguments in cases where `fullReset` capability is passed or the application is not yet installed.
- Added an `AbortController` that closes roku clients to ensure that no commands will be sent after the session deletion.
- Switched to Appium's built-in logger to make it easier to see which session logs are associated with.
- Set [libxmljs2](https://www.npmjs.com/package/libxmljs2/v/0.32.0) to `0.32.0` version to preserve the same OS/Node.js/CPU-s support as before.
- Added support for Windows OS.

### How to test

1. Install & build: `npm ci`
2. Install driver: `npx appium driver install --source local "$(pwd)"`
3. Start server: `npx appium server`

