### PR TITLE
feat: relative element references

### DIFF
--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -25,8 +25,8 @@ class RokuDriver
     return false;
   }
 
-  protected pressedKey?: string | undefined;
   protected fields: Record<string, string[]> | undefined;
+  protected pressedKey?: string | undefined;
   protected sdk!: SDK;
 }
 

--- a/src/helpers/appium.ts
+++ b/src/helpers/appium.ts
@@ -1,3 +1,4 @@
+export * from './appium/fromWebDriverElement.js';
 export * from './appium/getElement.js';
 export * from './appium/getElements.js';
 export * from './appium/getSelector.js';

--- a/src/helpers/appium/Selector.d.ts
+++ b/src/helpers/appium/Selector.d.ts
@@ -1,0 +1,5 @@
+export interface Selector {
+  using: string;
+  value: string;
+  index?: number;
+}

--- a/src/helpers/appium/fromWebDriverElement.ts
+++ b/src/helpers/appium/fromWebDriverElement.ts
@@ -1,0 +1,8 @@
+import { util } from '@appium/support';
+import type { Element } from '@appium/types';
+import type { Selector } from './Selector.ts';
+
+export function fromWebDriverElement(value: string | Element): Selector[] {
+  const id = typeof value === 'string' ? value : util.unwrapElement(value);
+  return JSON.parse(Buffer.from(id, 'base64').toString('utf8'));
+}

--- a/src/helpers/appium/getElements.ts
+++ b/src/helpers/appium/getElements.ts
@@ -1,11 +1,11 @@
 import * as domUtils from '../dom.js';
 import { getSelector } from './getSelector.js';
 
-export async function getElements(options: {
+export function getElements(options: {
   strategy: string;
   selector: string;
   parent: Element;
-}): Promise<Element[]> {
+}): Element[] {
   const [strategy, selector] = getSelector(options.strategy, options.selector);
 
   switch (strategy) {

--- a/src/helpers/appium/getSource.ts
+++ b/src/helpers/appium/getSource.ts
@@ -13,5 +13,22 @@ export async function getSource(
     xml = await this.sdk.ecp.queryAppUI();
   }
 
-  return domUtils.parse(xml);
+  const dom = domUtils.parse(xml);
+  generateIds(dom);
+  return dom;
+}
+
+function generateIds(node: Node): void {
+  if (domUtils.isTag(node) && !node.hasAttribute('id')) {
+    const id = node.getAttribute('uiElementId') || node.getAttribute('name');
+    if (id) {
+      node.setAttribute('id', id);
+    }
+  }
+
+  if (node.hasChildNodes()) {
+    for (let i = 0, n = node.childNodes.length; i < n; i++) {
+      generateIds(node.childNodes[i]!);
+    }
+  }
 }

--- a/src/helpers/appium/toWebDriverElement.ts
+++ b/src/helpers/appium/toWebDriverElement.ts
@@ -1,7 +1,14 @@
 import { util } from '@appium/support';
 import type { Element } from '@appium/types';
-import { getXPath } from '../dom/element/getXPath.js';
+import { getXPath } from '../dom.js';
+import type { Selector } from './Selector.ts';
 
-export function toWebDriverElement(node: Node): Element {
-  return util.wrapElement(Buffer.from(getXPath(node)).toString('base64'));
+export function toWebDriverElement(value: Node | Selector[]): Element {
+  value = Array.isArray(value)
+    ? value
+    : [{ using: 'xpath', value: getXPath(value) }];
+
+  return util.wrapElement(
+    Buffer.from(JSON.stringify(value)).toString('base64')
+  );
 }


### PR DESCRIPTION
Use locators to reference elements instead of their DOM positions, enabling verification of apps that modify the DOM without manual re-querying and allowing direct construction of element IDs to perform actions without a search phase.