### PR TITLE
fix: css-selector text pseudos

### DIFF
--- a/src/helpers/dom/internal/css-select.ts
+++ b/src/helpers/dom/internal/css-select.ts
@@ -1,6 +1,7 @@
 import type { Options } from 'css-select';
 import { getAttribute } from '../element/getAttribute.js';
 import { getTagName } from '../element/getTagName.js';
+import { getText as getTextContent } from '../element/getText.js';
 import { isTag } from '../element/isTag.js';
 
 export function existsOne(
@@ -43,7 +44,7 @@ function prevElementSibling(node: Node): Element | null {
 
 function getText(node: Node): string {
   if (!isTag(node)) return '';
-  return getAttribute(node, 'text') ?? '';
+  return getTextContent(node);
 }
 
 function hasAttrib(elem: Element, name: string): boolean {


### PR DESCRIPTION
Previously, those pseudos used the text of the candidate element, but now they will use the text returned by the `getText` driver command (i.e., visible text, including that from children elements).

```css
item:contains('case sensitive text');
```

```css
item:icontains('case insensitive text')
```