### PR TITLE
feat: `terminateApp` command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,20 +217,21 @@ driver.switchContext('ECP');
 
 ### Appium Commands
 
-| Command                                                | Description                                |
-| ------------------------------------------------------ | ------------------------------------------ |
-| [installApp](src/commands/installApp.ts)               | Install the channel if it is not installed |
-| [activateApp](src/commands/activateApp.ts)             | Launch the given channel                   |
-| [removeApp](src/commands/removeApp.ts)                 | Remove the given channel from the device   |
-| [isAppInstalled](src/commands/isAppInstalled.ts)       | Checks if a channel is installed           |
-| [queryAppState](src/commands/queryAppState.ts)         | Queries the channel state                  |
-| [pushFile](src/commands/pushFile.ts)                   | Push a file to the device                  |
-| [pullFile](src/commands/pullFile.ts)                   | Pull a file from the device                |
-| [pullFolder](src/commands/pullFolder.ts)               | Pull a folder from the device              |
-| [updateSettings](src/commands/updateSetting.ts)        | Updates current test session settings      |
-| [getCurrentContext](src/commands/getCurrentContext.ts) | Get the name of the current context        |
-| [setContext](src/commands/setContext.ts)               | Switches to the given context              |
-| [getContexts](src/commands/getContexts.ts)             | Get the names of available contexts        |
+| Command                                                | Description                                            |
+| ------------------------------------------------------ | ------------------------------------------------------ |
+| [installApp](src/commands/installApp.ts)               | Install the channel if it is not installed             |
+| [activateApp](src/commands/activateApp.ts)             | Launch the given channel                               |
+| [terminateApp](src/commands/terminateApp.ts)           | Terminate the channel (_Available since Roku OS 13.0_) |
+| [removeApp](src/commands/removeApp.ts)                 | Remove the given channel from the device               |
+| [isAppInstalled](src/commands/isAppInstalled.ts)       | Checks if a channel is installed                       |
+| [queryAppState](src/commands/queryAppState.ts)         | Queries the channel state                              |
+| [pushFile](src/commands/pushFile.ts)                   | Push a file to the device                              |
+| [pullFile](src/commands/pullFile.ts)                   | Pull a file from the device                            |
+| [pullFolder](src/commands/pullFolder.ts)               | Pull a folder from the device                          |
+| [updateSettings](src/commands/updateSetting.ts)        | Updates current test session settings                  |
+| [getCurrentContext](src/commands/getCurrentContext.ts) | Get the name of the current context                    |
+| [setContext](src/commands/setContext.ts)               | Switches to the given context                          |
+| [getContexts](src/commands/getContexts.ts)             | Get the names of available contexts                    |
 
 ### Roku Commands
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,3 +29,4 @@ export * from './commands/removeApp.js';
 export * from './commands/setContext.js';
 export * from './commands/setUrl.js';
 export * from './commands/setValue.js';
+export * from './commands/terminateApp.js';

--- a/src/commands/terminateApp.ts
+++ b/src/commands/terminateApp.ts
@@ -1,0 +1,31 @@
+import type { AppId } from '@dlenroc/roku-ecp';
+import type { Driver } from '../Driver.ts';
+import * as appiumUtils from '../helpers/appium.js';
+
+export async function terminateApp(
+  this: Driver,
+  appId: string
+): Promise<boolean> {
+  let state = await appiumUtils.retrying({
+    timeout: 1e4,
+    validate: (state, error) => !error && state! <= 2,
+    command: async () => {
+      await this.sdk.ecp.exitApp({ appId: appId as AppId });
+      return this.queryAppState(appId);
+    },
+  });
+
+  await this.sdk.debugServer.clearLaunchCaches({
+    signal: AbortSignal.timeout(1e4),
+  });
+
+  if (state == 2) {
+    state = await appiumUtils.retrying({
+      timeout: 1e4,
+      validate: (state, error) => !error && state! <= 1,
+      command: () => this.queryAppState(appId),
+    });
+  }
+
+  return state === 1;
+}

--- a/src/helpers/sdk.ts
+++ b/src/helpers/sdk.ts
@@ -140,7 +140,7 @@ export class SDK {
       new DebugServerExecutor({
         signal,
         hostname: options.ip,
-        port: 8085,
+        port: 8080,
       })
     );
 


### PR DESCRIPTION
Implemented `terminateApp` command using [app-exit](https://developer.roku.com/docs/developer-program/dev-tools/external-control-api.md#querychannel-state-example) endpoint available since Roku OS 13.
