### PR TITLE
feat!: foreground app with `activateApp`

### DIFF
--- a/src/commands/activateApp.ts
+++ b/src/commands/activateApp.ts
@@ -1,13 +1,14 @@
 import { errors } from '@appium/base-driver';
 import * as ecp from '@dlenroc/roku-ecp';
 import type { Driver } from '../Driver.ts';
+import * as appiumUtils from '../helpers/appium.js';
 
 export async function activateApp(
   this: Driver,
   appId: string,
   options?: unknown
 ): Promise<void> {
-  options ??= { odc_clear_registry: false };
+  options ??= {};
 
   if (typeof options !== 'object' || Array.isArray(options)) {
     throw new errors.InvalidArgumentError('Launch arguments must be an object');
@@ -16,5 +17,21 @@ export async function activateApp(
   await this.sdk.ecp.launch({
     appId: appId as ecp.AppId,
     params: options as Record<string, unknown>,
+  });
+
+  let screensaverDismissed = false;
+
+  await appiumUtils.retrying({
+    timeout: 1e4,
+    validate: (state, error) => !error && state === 4,
+    command: async () => {
+      const state = await this.queryAppState(appId);
+      if (!screensaverDismissed && state === 3) {
+        screensaverDismissed = true;
+        await this.sdk.ecp.keypress({ key: 'Enter' });
+      }
+
+      return state;
+    },
   });
 }

--- a/src/commands/setUrl.ts
+++ b/src/commands/setUrl.ts
@@ -1,22 +1,17 @@
 import { errors } from '@appium/base-driver';
-import type { AppId } from '@dlenroc/roku-ecp';
 import { URL } from 'node:url';
 import type { Driver } from '../Driver.ts';
 
 export async function setUrl(this: Driver, url: string): Promise<void> {
   const { host, pathname, searchParams } = new URL(url);
-  const app = pathname.slice(1) as AppId;
-
-  let params: Record<string, string> = {};
-  for (const [key, value] of searchParams) {
-    params[key] = value;
-  }
+  const app = pathname.slice(1);
+  const params = Object.fromEntries(searchParams);
 
   switch (host) {
     case 'launch':
-      return await this.sdk.ecp.launch({ appId: app, params });
+      return this.activateApp(app, params);
     case 'input':
-      return await this.sdk.ecp.input(params);
+      return this.sdk.ecp.input(params);
     default:
       throw new errors.InvalidArgumentError('Unsupported URL format');
   }


### PR DESCRIPTION
If `activateApp` is called without options and the target app is already launched but either suspended or in the background, it will be brought to the foreground. If at least one option is passed, the channel will be relaunched with new launch arguments, even if it is already running with the same values.

PS: The same will apply to `launch` deep link.

```ts
await driver.url('roku://launch/dev');
```