### PR TITLE
feat: receiving BrightScript logs via BiDi

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ const capabilities = {
 };
 ```
 
+### BrightScript Logging
+
+```ts
+// Forward logs to the console
+driver.on('log.entryAdded', (entry) => console.log(entry.text));
+
+// Subscribe to BrightScript logs
+await driver.sessionSubscribe({ events: ['log.entryAdded'] });
+
+// Unsubscribe from BrightScript logs (optional)
+await driver.sessionUnsubscribe({ events: ['log.entryAdded'] });
+```
+
+> **Note:**
+
 ### Actions
 
 The following action types are supported:
@@ -160,7 +175,8 @@ If adding a vendor prefix is a problem, [@appium/relaxed-caps-plugin](https://ww
 | ------------------------------------- | :------: | :-----: | ------------------------------------------------------------------------------------------------------------------------------- |
 | `platformName`                        |    +     | string  | Must be `roku`                                                                                                                  |
 | `appium:automationName`               |    +     | string  | Must be `roku`                                                                                                                  |
-| `appium:deviceName`                   |   +/-    | String  | Helps webdriver clients understand that they are dealing with appium                                                            |
+| `appium:deviceName`                   |   +/-    | string  | Helps webdriver clients understand that they are dealing with appium                                                            |
+| `webSocketUrl`                        |    -     | boolean | Opt in to the use of the Bidi protocol. Defaults to `false`.                                                                    |
 | `appium:app`                          |    -     | string  | The absolute local path or remote http URL to channel                                                                           |
 | `appium:noReset`                      |    -     | boolean | Do not stop app, do not clear app data, and do not uninstall app                                                                |
 | `appium:printPageSourceOnFindFailure` |    -     | boolean | When a find operation fails, print the current page source. Defaults to `false`                                                 |
@@ -232,6 +248,13 @@ driver.switchContext('ECP');
 | [getCurrentContext](src/commands/getCurrentContext.ts) | Get the name of the current context                    |
 | [setContext](src/commands/setContext.ts)               | Switches to the given context                          |
 | [getContexts](src/commands/getContexts.ts)             | Get the names of available contexts                    |
+
+### BiDi Commands
+
+| Command                                            | Description                                                     |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| [bidiSubscribe](src/commands/bidiSubscribe.ts)     | Enables certain events either globally or for a set of contexts |
+| [bidiUnsubscribe](src/commands/bidiUnsubscribe.ts) | Disables events either globally or for a set of contexts        |
 
 ### Roku Commands
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ const capabilities = {
 
 ### BrightScript Logging
 
-```ts
+```js
 // Forward logs to the console
 driver.on('log.entryAdded', (entry) => console.log(entry.text));
 
@@ -196,7 +196,7 @@ The supported commands are listed in the sections below but note that they may h
 
 Example: calling the `setContext` command
 
-```typescript
+```js
 // Java
 driver.context('ECP');
 

--- a/src/Driver.ts
+++ b/src/Driver.ts
@@ -1,5 +1,6 @@
 import { BaseDriver, DeviceSettings } from '@appium/base-driver';
 import type { ExternalDriver } from '@appium/types';
+import type { Socket } from 'node:net';
 import { capabilitiesConstraints } from './CapabilitiesConstraints.js';
 import * as Commands from './commands.js';
 import { updateSetting } from './commands/internal/updateSetting.js';
@@ -10,6 +11,7 @@ class RokuDriver
   implements ExternalDriver<typeof capabilitiesConstraints>
 {
   // Configurations
+  public override doesSupportBidi = true;
   public override desiredCapConstraints = capabilitiesConstraints;
   public override settings = new DeviceSettings({}, updateSetting.bind(this));
   public override supportedLogTypes = {};
@@ -25,6 +27,7 @@ class RokuDriver
     return false;
   }
 
+  protected socket?: Socket | undefined;
   protected fields: Record<string, string[]> | undefined;
   protected pressedKey?: string | undefined;
   protected sdk!: SDK;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,7 @@
 export * from './commands/activateApp.js';
 export * from './commands/active.js';
+export * from './commands/bidiSubscribe.js';
+export * from './commands/bidiUnsubscribe.js';
 export * from './commands/clear.js';
 export * from './commands/click.js';
 export * from './commands/createSession.js';

--- a/src/commands/bidiSubscribe.ts
+++ b/src/commands/bidiSubscribe.ts
@@ -1,0 +1,28 @@
+import { BaseDriver } from '@appium/base-driver';
+import { Socket } from 'node:net';
+import type { Driver } from '../Driver.ts';
+
+export async function bidiSubscribe(
+  this: Driver,
+  events: string[],
+  contexts: string[]
+): Promise<void> {
+  await BaseDriver.prototype.bidiSubscribe.call(this, events, contexts);
+
+  if (!this.socket && this.bidiEventSubs['log.entryAdded']) {
+    this.socket = new Socket({ signal: this.sdk.controller.signal });
+    this.socket.connect(8085, this.opts.ip);
+    this.socket.setEncoding('utf8');
+    this.socket.on('data', (text) => {
+      this.eventEmitter.emit('bidiEvent', {
+        method: 'log.entryAdded',
+        params: {
+          level: 'debug',
+          text,
+          timestamp: Date.now(),
+          type: 'brightscript',
+        },
+      });
+    });
+  }
+}

--- a/src/commands/bidiUnsubscribe.ts
+++ b/src/commands/bidiUnsubscribe.ts
@@ -1,0 +1,15 @@
+import { BaseDriver } from '@appium/base-driver';
+import type { Driver } from '../Driver.ts';
+
+export async function bidiUnsubscribe(
+  this: Driver,
+  events: string[],
+  contexts: string[]
+): Promise<void> {
+  await BaseDriver.prototype.bidiUnsubscribe.call(this, events, contexts);
+
+  if (this.socket && !this.bidiEventSubs['log.entryAdded']) {
+    this.socket.end();
+    this.socket = undefined;
+  }
+}


### PR DESCRIPTION
Added BiDi support and a basic version of the `log.entryAdded` event for consuming device logs.