### PR TITLE
fix: terminate app if it is already installed

### DIFF
--- a/src/commands/createSession.ts
+++ b/src/commands/createSession.ts
@@ -24,6 +24,20 @@ export async function createSession(
   );
 
   this.opts.context ??= 'ECP';
+  this.opts.arguments ??= {};
+
+  if (this.opts.entryPoint) {
+    this.opts.arguments['odc_entry_point'] = this.opts.entryPoint;
+  }
+
+  if (!this.opts.noReset) {
+    this.opts.arguments['odc_clear_registry'] = true;
+  }
+
+  if (this.opts.registry && Object.keys(this.opts.registry).length) {
+    this.opts.arguments['odc_registry'] = this.opts.registry;
+  }
+
   this.sdk = new SDK({
     ip: this.opts.ip,
     username: this.opts.username ?? 'rokudev',
@@ -32,12 +46,7 @@ export async function createSession(
 
   if (this.opts.app) {
     await this.installApp(this.opts.app);
-    await this.activateApp('dev', {
-      odc_clear_registry: !this.opts.noReset,
-      ...(this.opts.entryPoint && { odc_entry_point: this.opts.entryPoint }),
-      ...(this.opts.registry && { odc_registry: this.opts.registry }),
-      ...this.opts.arguments,
-    });
+    await this.activateApp('dev', this.opts.arguments);
   }
 
   return session;

--- a/src/commands/deleteSession.ts
+++ b/src/commands/deleteSession.ts
@@ -1,25 +1,21 @@
 import { BaseDriver, errors } from '@appium/base-driver';
-import type { Driver } from '../Driver.ts';
-import * as appiumUtils from '../helpers/appium.js';
+import { Driver } from '../Driver.js';
 import { SDK } from '../helpers/sdk.js';
 
 export async function deleteSession(
   this: Driver,
   sessionId?: string | null
 ): Promise<void> {
-  try {
-    this.sdk.controller.abort(
-      new errors.UnknownError('The session was terminated!')
-    );
+  this.sdk.controller.abort(
+    new errors.UnknownError('The session was terminated!')
+  );
 
+  try {
     const sdk = new SDK(this.sdk);
     if (this.opts.shouldTerminateApp) {
-      await sdk.ecp.keypress({ key: 'Home' });
-      await appiumUtils.retrying({
-        timeout: 1e4,
-        validate: (state) => !!state && !!('id' in state.app),
-        command: () => sdk.ecp.queryActiveApp(),
-      });
+      const driver = new Driver(this.opts);
+      driver.sdk = sdk;
+      await driver.terminateApp('dev');
     } else if (this.pressedKey) {
       await sdk.ecp.keyup({ key: this.pressedKey });
     }

--- a/src/commands/installApp.ts
+++ b/src/commands/installApp.ts
@@ -23,31 +23,18 @@ export async function installApp(this: Driver, appPath: string): Promise<void> {
 
     if (alreadyInstalled) {
       this.log.info('Channel is already installed');
+      await this.terminateApp('dev');
       return;
     }
   }
 
   this.log.info('Install channel');
-  const patchedApp = await odc.inject(source.buffer);
-
-  await this.sdk.developerServer.installChannel({
-    content: new Uint8Array(patchedApp),
-  });
+  const content = new Uint8Array(await odc.inject(source.buffer));
+  await this.sdk.developerServer.installChannel({ content });
 
   await appiumUtils.retrying({
     timeout: 1e4,
     validate: (state) => state === 4,
     command: () => this.queryAppState('dev'),
   });
-
-  await this.performActions([
-    {
-      id: 'remote',
-      type: 'key',
-      actions: [
-        { type: 'keyDown', value: 'Home' },
-        { type: 'keyUp', value: 'Home' },
-      ],
-    },
-  ]);
 }


### PR DESCRIPTION
Reused `terminateApp` in `deleteSession` and made `installApp` behavior more predictable and performant.

- If the app is not installed, it will be installed and run (default Roku platform behavior).
- If the app is already installed and launched, it will be terminated to ensure deterministic behavior.
